### PR TITLE
Tracker min seed

### DIFF
--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -70,6 +70,8 @@ tracker:
   #   max_ratio: 5.0
   # <OPTIONAL> Will set the torrent Maximum seeding time (min) until torrent is stopped from seeding. -2 means the global limit should be used, -1 means no limit.
   #   max_seeding_time: 129600
+  # <OPTIONAL> Will ensure that noHL torrents from this tracker are not deleted by cleanup variable if torrent has not yet met the minimum seeding time (min).
+  #   min_seeding_time: 2000  
   # <OPTIONAL> Will limit the upload speed KiB/s (KiloBytes/second) (-1 sets the limit to infinity)
   #   limit_upload_speed: 150
   # <OPTIONAL> Set this to the notifiarr react name. This is used to add indexer reactions to the notifications sent by Notifiarr
@@ -84,6 +86,7 @@ tracker:
       - tag3
     max_ratio: 5.0
     max_seeding_time: 129600
+    min_seeding_time: 30400
     limit_upload_speed: 150
     notifiarr: avistaz
   beyond-hd:
@@ -145,7 +148,8 @@ nohardlinks:
     max_seeding_time: 86400
     # <OPTIONAL> Limit Upload Speed var: Will limit the upload speed KiB/s (KiloBytes/second) (`-1` : No Limit)
     limit_upload_speed:
-    # <OPTIONAL> min seeding time var: Will ensure that torrent is not deleted by cleanup variable if torrent does not meet minimum seeding time (min).
+    # <OPTIONAL> min seeding time var: Will prevent torrent deletion by cleanup variable if torrent has not yet minimum seeding time (min). 
+    # Delete this key from a category's config to use the tracker's configured min_seeding_time. Will default to 0 if not specified for the category or tracker. 
     min_seeding_time: 43200
 
   # Can have additional categories set with separate ratio/seeding times defined.
@@ -162,8 +166,8 @@ nohardlinks:
     max_seeding_time: 86400
     # <OPTIONAL> Limit Upload Speed var: Will limit the upload speed KiB/s (KiloBytes/second) (`-1` : No Limit)
     limit_upload_speed:
-    # <OPTIONAL> min seeding time var: Will ensure that torrent is not deleted by cleanup variable if torrent does not meet minimum seeding time (min).
-    min_seeding_time: 43200
+    # <OPTIONAL> min seeding time var: Will prevent torrent deletion by cleanup variable if torrent has not yet minimum seeding time (min). 
+    # min_seeding_time: # Not specified for this category; tracker's value will be used. Will default to 0 if not specified for the category or tracker. 
 
 recyclebin:
   # Recycle Bin method of deletion will move files into the recycle bin (Located in /root_dir/.RecycleBin) instead of directly deleting them in qbit

--- a/modules/config.py
+++ b/modules/config.py
@@ -198,7 +198,7 @@ class Config:
                     self.nohardlinks[cat]['max_seeding_time'] = self.util.check_for_attribute(self.data, "max_seeding_time", parent="nohardlinks", subparent=cat,
                                                                                               var_type="int", default_int=-2, default_is_none=True, do_print=False)
                     self.nohardlinks[cat]['min_seeding_time'] = self.util.check_for_attribute(self.data, "min_seeding_time", parent="nohardlinks", subparent=cat,
-                                                                                              var_type="int", default_int=0, default=0, do_print=False)
+                                                                                              var_type="int", default_int=0, default_is_none=True, do_print=False)
                     self.nohardlinks[cat]['limit_upload_speed'] = self.util.check_for_attribute(self.data, "limit_upload_speed", parent="nohardlinks", subparent=cat,
                                                                                                 var_type="int", default_int=-1, default_is_none=True, do_print=False)
                 else:
@@ -293,6 +293,7 @@ class Config:
         tracker = {}
         tracker['tag'] = None
         tracker['max_ratio'] = None
+        tracker['min_seeding_time'] = None        
         tracker['max_seeding_time'] = None
         tracker['limit_upload_speed'] = None
         tracker['notifiarr'] = None
@@ -331,6 +332,8 @@ class Config:
                             if isinstance(tracker['tag'], str): tracker['tag'] = [tracker['tag']]
                             tracker['max_ratio'] = self.util.check_for_attribute(self.data, "max_ratio", parent="tracker", subparent=tag_url,
                                                                                  var_type="float", default_int=-2, default_is_none=True, do_print=False, save=False)
+                            tracker['min_seeding_time'] = self.util.check_for_attribute(self.data, "min_seeding_time", parent="tracker", subparent=tag_url,
+                                                                                        var_type="int", default_int=0, default_is_none=True, do_print=False, save=False)
                             tracker['max_seeding_time'] = self.util.check_for_attribute(self.data, "max_seeding_time", parent="tracker", subparent=tag_url,
                                                                                         var_type="int", default_int=-2, default_is_none=True, do_print=False, save=False)
                             tracker['limit_upload_speed'] = self.util.check_for_attribute(self.data, "limit_upload_speed", parent="tracker", subparent=tag_url,

--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -350,10 +350,18 @@ class Qbt:
                                 self.config.send_notifications(attr)
                             # Cleans up previously tagged noHL torrents
                             else:
+                                # Determine min_seeding_time.  noHl > Tracker w/ default 0
+                                min_seeding_time = 0
+                                tracker = self.config.get_tags([x.url for x in torrent.trackers if x.url.startswith('http')])
+                                if nohardlinks[category]["min_seeding_time"]:
+                                    min_seeding_time = nohardlinks[category]["min_seeding_time"]
+                                elif tracker["min_seeding_time"]:
+                                    min_seeding_time = tracker["min_seeding_time"]
+
                                 # Deletes torrent with data if cleanup is set to true and meets the ratio/seeding requirements
                                 if (nohardlinks[category]['cleanup'] and torrent.state_enum.is_paused and len(nohardlinks[category]) > 0
-                                   and torrent.seeding_time > (nohardlinks[category]["min_seeding_time"]*60)):
-                                    tdel_dict[torrent.name] = torrent['content_path'].replace(root_dir, root_dir)
+                                    and torrent.seeding_time > (min_seeding_time*60)):
+                                        tdel_dict[torrent.name] = torrent['content_path'].replace(root_dir, root_dir)
                     # Checks to see if previous noHL tagged torrents now have hard links.
                     if (not (util.nohardlink(torrent['content_path'].replace(root_dir, root_dir))) and ('noHL' in torrent.tags)):
                         num_untag += 1


### PR DESCRIPTION
## Description

Adding new option to specify the min_seeding_time per-tracker that will be honored when determining noHL deletion.  The noHL categories min_seeding_time takes precedence over the tracker's min_seeding_time. If neither specifies a min_seeding_time than the previous default of 0 is still used. 

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have added or updated the docstring for new or existing methods
- [N/A] I have added tests when applicable