### PR TITLE
NoHL torrents been removed when criteria not met

### DIFF
--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -548,12 +548,12 @@ class Qbt:
                                     tracker["url"],
                                 )
                                 if tor_reach_seed_limit:
-                                    if torrent.name not in tdel_dict:
-                                        tdel_dict[torrent.name] = {}
-                                    tdel_dict[torrent.name]["content_path"] = torrent["content_path"].replace(
+                                    if torrent.hash not in tdel_dict:
+                                        tdel_dict[torrent.hash] = {}
+                                    tdel_dict[torrent.hash]["content_path"] = torrent["content_path"].replace(
                                         root_dir, remote_dir
                                     )
-                                    tdel_dict[torrent.name]["body"] = tor_reach_seed_limit
+                                    tdel_dict[torrent.hash]["body"] = tor_reach_seed_limit
                                 else:
                                     # Updates torrent to see if "MinSeedTimeNotReached" tag has been added
                                     torrent = self.get_torrents({"torrent_hashes": [torrent.hash]}).data[0]
@@ -608,19 +608,20 @@ class Qbt:
                     torrent_list = self.get_torrents({"category": category, "status_filter": "completed"})
                     for torrent in torrent_list:
                         t_name = torrent.name
-                        if t_name in tdel_dict.keys() and "noHL" in torrent.tags:
+                        t_hash = torrent.hash
+                        if t_hash in tdel_dict.keys() and "noHL" in torrent.tags:
                             t_count = self.torrentinfo[t_name]["count"]
                             t_msg = self.torrentinfo[t_name]["msg"]
                             t_status = self.torrentinfo[t_name]["status"]
                             # Double check that the content path is the same before we delete anything
-                            if torrent["content_path"].replace(root_dir, remote_dir) == tdel_dict[t_name]["content_path"]:
+                            if torrent["content_path"].replace(root_dir, remote_dir) == tdel_dict[t_hash]["content_path"]:
                                 tracker = self.config.get_tags(torrent.trackers)
                                 body = []
                                 body += logger.print_line(logger.insert_space(f"Torrent Name: {t_name}", 3), self.config.loglevel)
                                 body += logger.print_line(
                                     logger.insert_space(f'Tracker: {tracker["url"]}', 8), self.config.loglevel
                                 )
-                                body += logger.print_line(tdel_dict[t_name]["body"], self.config.loglevel)
+                                body += logger.print_line(tdel_dict[t_hash]["body"], self.config.loglevel)
                                 body += logger.print_line(
                                     logger.insert_space("Cleanup: True [No hard links found and meets Share Limits.]", 8),
                                     self.config.loglevel,


### PR DESCRIPTION
## Description

Cross-seeded torrents with unmatched NoHL criteria were getting deleted because they have the same name as the original torrent whose seeding criteria had been met. Using the hash of a torrent makes this work reliably as the hash is unique. 

Original logs https://logs.notifiarr.com/?5f566cd42108f58f#J5Bc3P1SqZUUapywRaFjQvPaJHG3fU2yQMuQAmgdNVHC
The seeding time on the 2 none TL torrents is incorrect and has been matched to the TL torrents

Logs with this change https://logs.notifiarr.com/?a4a914e0fc0aa5ed#5bNpRDW3JGprqghhQTq3PaDSwup8gHWjf5PAszVPfhA5
Only the 2 TL torrents are removed, which is expected

Link to discord message:
https://discord.com/channels/764440599066574859/921548253948964904/1060521192164958288
https://logs.notifiarr.com/?5f566cd42108f58f#J5Bc3P1SqZUUapywRaFjQvPaJHG3fU2yQMuQAmgdNVHC

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
