### PR TITLE
Fix remove_orphans crashing in certain cases

### DIFF
--- a/modules/util.py
+++ b/modules/util.py
@@ -307,19 +307,22 @@ def copy_files(src, dest):
 def remove_empty_directories(pathlib_root_dir, pattern):
     """Remove empty directories recursively."""
     pathlib_root_dir = Path(pathlib_root_dir)
-    # list all directories recursively and sort them by path,
-    # longest first
-    longest = sorted(
-        pathlib_root_dir.glob(pattern),
-        key=lambda p: len(str(p)),
-        reverse=True,
-    )
-    longest.append(pathlib_root_dir)
-    for pdir in longest:
-        try:
-            pdir.rmdir()  # remove directory if empty
-        except OSError:
-            continue  # catch and continue if non-empty
+    try:
+        # list all directories recursively and sort them by path,
+        # longest first
+        longest = sorted(
+            pathlib_root_dir.glob(pattern),
+            key=lambda p: len(str(p)),
+            reverse=True,
+        )
+        longest.append(pathlib_root_dir)  # delete the folder itself if it's empty
+        for pdir in longest:
+            try:
+                pdir.rmdir()  # remove directory if empty
+            except (FileNotFoundError, OSError):
+                continue  # catch and continue if non-empty, folders within could already be deleted if run in parallel
+    except FileNotFoundError:
+        pass  # if this is being run in parallel, pathlib_root_dir could already be deleted
 
 
 def nohardlink(file, notify):


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

We updated remove_orphans to delete empty directories in parallel however the code for actually deleting the directories didn't have anything to handle the case of deleting a directory twice and would instead just crash.

## Type of change
 Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
