### PR TITLE
Fix crash in cross-seed module

### DIFF
--- a/modules/core/cross_seed.py
+++ b/modules/core/cross_seed.py
@@ -72,7 +72,7 @@ class CrossSeed:
                     logger.print_line(f"Found {t_name} in {dir_cs} but original torrent is not complete.", self.config.loglevel)
                     logger.print_line("Not adding to qBittorrent", self.config.loglevel)
             else:
-                error = f"{t_name} not found in torrents. Cross-seed Torrent not added to qBittorrent."
+                error = f"{tr_name} not found in torrents. Cross-seed Torrent not added to qBittorrent."
                 if self.config.dry_run:
                     logger.print_line(error, self.config.loglevel)
                 else:


### PR DESCRIPTION
## Description
The code was referencing a variable that would never be assigned on that branch, it was likely a typo as there is a similar variable that is assigned. I have swapped it to use the similarly named variable.

Fixes #287

## Type of change
Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
