### PR TITLE
FEAT: bypass qBittorrent version check

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-3.6.3-develop6
+3.6.3-develop7

--- a/modules/config.py
+++ b/modules/config.py
@@ -29,6 +29,7 @@ COMMANDS = [
     "rem_orphaned",
     "tag_nohardlinks",
     "skip_cleanup",
+    "skip_qb_version_check",
     "dry_run",
 ]
 
@@ -82,6 +83,7 @@ class Config:
                 logger.debug(f"    --rem-orphaned (QBT_REM_ORPHANED): {self.commands['rem_orphaned']}")
                 logger.debug(f"    --tag-nohardlinks (QBT_TAG_NOHARDLINKS): {self.commands['tag_nohardlinks']}")
                 logger.debug(f"    --skip-cleanup (QBT_SKIP_CLEANUP): {self.commands['skip_cleanup']}")
+                logger.debug(f"    --skip-qb-version-check (QBT_SKIP_QB_VERSION_CHECK): {self.commands['skip_qb_version_check']}")
                 logger.debug(f"    --dry-run (QBT_DRY_RUN): {self.commands['dry_run']}")
         else:
             self.commands = args

--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -48,19 +48,22 @@ class Qbt:
                     f"Qbittorrent Error: qbit_manage is only compatible with {self.MIN_SUPPORTED_VERSION} or higher. "
                     f"You are currently on {self.current_version}."
                     + "\n"
-                    + f"Please upgrade to your Qbittorrent version to {self.MIN_SUPPORTED_VERSION} or higher to use qbit_manage."
+                    + f"Please upgrade your qBittorrent version to {self.MIN_SUPPORTED_VERSION} or higher to use qbit_manage."
                 )
             elif not Version.is_app_version_supported(self.current_version):
                 ex = (
                     f"Qbittorrent Error: qbit_manage is only compatible with {self.SUPPORTED_VERSION} or lower. "
                     f"You are currently on {self.current_version}."
                     + "\n"
-                    + f"Please downgrade to your Qbittorrent version to {self.SUPPORTED_VERSION} to use qbit_manage."
+                    + f"Please downgrade your qBittorrent version to {self.SUPPORTED_VERSION} to use qbit_manage."
                 )
             if ex:
                 self.config.notify(ex, "Qbittorrent")
                 logger.print_line(ex, "CRITICAL")
-                sys.exit(0)
+                if self.config.commands["skip_qb_version_check"]:
+                    logger.print_line("Continuing because qBittorrent version check is bypassed... Please do not ask for support!")
+                else:
+                    sys.exit(0)
             else:
                 logger.info("Qbt Connection Successful")
         except LoginFailed as exc:

--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -61,7 +61,9 @@ class Qbt:
                 self.config.notify(ex, "Qbittorrent")
                 logger.print_line(ex, "CRITICAL")
                 if self.config.commands["skip_qb_version_check"]:
-                    logger.print_line("Continuing because qBittorrent version check is bypassed... Please do not ask for support!")
+                    logger.print_line(
+                        "Continuing because qBittorrent version check is bypassed... Please do not ask for support!"
+                    )
                 else:
                     sys.exit(0)
             else:

--- a/qbit_manage.py
+++ b/qbit_manage.py
@@ -150,6 +150,15 @@ parser.add_argument(
     help="Use this to skip cleaning up Recycle Bin/Orphaned directory.",
 )
 parser.add_argument(
+    "-svc",
+    "--skip-qb-version-check",
+    dest="skip_qb_version_check",
+    action="store_true",
+    default=False,
+    # help="Bypass qBittorrent/libtorrent version compatibility check. You run the risk of undesirable behavior and will receive no support.",
+    help=argparse.SUPPRESS,
+)
+parser.add_argument(
     "-dr",
     "--dry-run",
     dest="dry_run",
@@ -228,6 +237,7 @@ tag_tracker_error = get_arg("QBT_TAG_TRACKER_ERROR", args.tag_tracker_error, arg
 rem_orphaned = get_arg("QBT_REM_ORPHANED", args.rem_orphaned, arg_bool=True)
 tag_nohardlinks = get_arg("QBT_TAG_NOHARDLINKS", args.tag_nohardlinks, arg_bool=True)
 skip_cleanup = get_arg("QBT_SKIP_CLEANUP", args.skip_cleanup, arg_bool=True)
+skip_qb_version_check = get_arg("QBT_SKIP_QB_VERSION_CHECK", args.skip_qb_version_check, arg_bool=True)
 dry_run = get_arg("QBT_DRY_RUN", args.dry_run, arg_bool=True)
 log_level = get_arg("QBT_LOG_LEVEL", args.log_level)
 divider = get_arg("QBT_DIVIDER", args.divider)
@@ -275,6 +285,7 @@ for v in [
     "rem_orphaned",
     "tag_nohardlinks",
     "skip_cleanup",
+    "skip_qb_version_check",
     "dry_run",
     "log_level",
     "divider",
@@ -572,6 +583,7 @@ if __name__ == "__main__":
     logger.debug(f"    --rem-orphaned (QBT_REM_ORPHANED): {rem_orphaned}")
     logger.debug(f"    --tag-nohardlinks (QBT_TAG_NOHARDLINKS): {tag_nohardlinks}")
     logger.debug(f"    --skip-cleanup (QBT_SKIP_CLEANUP): {skip_cleanup}")
+    logger.debug(f"    --skip-qb-version-check (QBT_SKIP_QB_VERSION_CHECK): {skip_qb_version_check}")
     logger.debug(f"    --dry-run (QBT_DRY_RUN): {dry_run}")
     logger.debug(f"    --log-level (QBT_LOG_LEVEL): {log_level}")
     logger.debug(f"    --divider (QBT_DIVIDER): {divider}")

--- a/qbit_manage.py
+++ b/qbit_manage.py
@@ -155,7 +155,8 @@ parser.add_argument(
     dest="skip_qb_version_check",
     action="store_true",
     default=False,
-    # help="Bypass qBittorrent/libtorrent version compatibility check. You run the risk of undesirable behavior and will receive no support.",
+    # help="Bypass qBittorrent/libtorrent version compatibility check. "
+    # "You run the risk of undesirable behavior and will receive no support.",
     help=argparse.SUPPRESS,
 )
 parser.add_argument(


### PR DESCRIPTION
## Description

add feature `--skip-qb-version-check` (`QBT_SKIP_QB_VERSION_CHECK`). allows running qbit_manage on unsupported versions of qBittorrent/libtorrent.

this is hidden/suppressed for now in argparse to reduce support burden. it also comes with disclaimers about not receiving support if you switch it on.

even though this is imo a setting and not a 'command', i shoehorned it in there because the code is not extensible enough as-is to accommodate adding an env var any other way. i noticed this was already abused for things like `QBT_SKIP_CLEANUP`, so i hope that's ok. i didn't want to touch too much code.

i'm personally using this to test new/unsupported builds, and i figured it would be useful to others.

_(fyi, it works fine with qBittorrent 4.6alpha1 as far as i can tell. i'm using it because its web api performance got a huge speedup. the qb WebUI is quite snappy now with thousands of torrents. i shared my personal tests [here](https://github.com/qbittorrent/qBittorrent/issues/12093#issuecomment-1564280976).)_

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have modified this PR to merge to the develop branch
