### PR TITLE
Bump qbittorrent-api to v2023.9.53

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bencodepy==0.9.5
 GitPython==3.1.34
-qbittorrent-api==2023.7.52
+qbittorrent-api==2023.9.53
 requests==2.31.0
 retrying==1.3.4
 ruamel.yaml==0.17.32


### PR DESCRIPTION
## Description

Update to use the latest version of qbittorrent-api (v2023.9.53) for compatibility with qBittorrent v4.5.5

Fixes #377 

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have modified this PR to merge to the develop branch
