### PR TITLE
Special mapping to leave torrents uncategorized on cat-update

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-4.0.5-develop4
+4.0.5-develop5

--- a/modules/core/category.py
+++ b/modules/core/category.py
@@ -15,10 +15,9 @@ class Category:
         self.notify_attr = []  # List of single torrent attributes to send to notifiarr
 
         self.uncategorized_mapping = "Uncategorized"
-        
+
         self.category()
         self.config.webhooks_factory.notify(self.torrents_updated, self.notify_attr, group_by="category")
-
 
     def category(self):
         """Update category for torrents that don't have any category defined and returns total number categories updated"""

--- a/modules/core/category.py
+++ b/modules/core/category.py
@@ -14,8 +14,11 @@ class Category:
         self.torrents_updated = []  # List of torrents updated
         self.notify_attr = []  # List of single torrent attributes to send to notifiarr
 
+        self.uncategorized_mapping = "Uncategorized"
+        
         self.category()
         self.config.webhooks_factory.notify(self.torrents_updated, self.notify_attr, group_by="category")
+
 
     def category(self):
         """Update category for torrents that don't have any category defined and returns total number categories updated"""
@@ -23,6 +26,9 @@ class Category:
         torrent_list = self.qbt.get_torrents({"category": "", "status_filter": "completed"})
         for torrent in torrent_list:
             new_cat = self.qbt.get_category(torrent.save_path)
+            if new_cat == self.uncategorized_mapping:
+                logger.print_line(f"{torrent.name} remains uncategorized.", self.config.loglevel)
+                continue
             self.update_cat(torrent, new_cat, False)
 
         # Change categories

--- a/modules/core/category.py
+++ b/modules/core/category.py
@@ -13,7 +13,6 @@ class Category:
         self.stats = 0
         self.torrents_updated = []  # List of torrents updated
         self.notify_attr = []  # List of single torrent attributes to send to notifiarr
-
         self.uncategorized_mapping = "Uncategorized"
 
         self.category()


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

Added a mapping "Uncategorized" to use in `cat` in the config file to indicate that the torrents at the defined `save_path` should stay uncategorized. Maybe requires a change in the documentation to say that the mapping exists.

Fixes #395

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have modified this PR to merge to the develop branch
