### PR TITLE
Add force_auto_tmm_ignore_tags feature

### DIFF
--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -26,6 +26,9 @@ qbt:
 
 settings:
   force_auto_tmm: False # Will force qBittorrent to enable Automatic Torrent Management for each torrent.
+  force_auto_tmm_ignore_tags: #Torrents with these tags will be ignored when force_auto_tmm is enabled.
+    - cross-seed
+    - Upload 
   tracker_error_tag: issue # Will set the tag of any torrents that do not have a working tracker.
   nohardlinks_tag: noHL # Will set the tag of any torrents with no hardlinks.
   share_limits_tag: ~share_limit # Will add this tag when applying share limits to provide an easy way to filter torrents by share limit group/priority for each torrent

--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -28,7 +28,7 @@ settings:
   force_auto_tmm: False # Will force qBittorrent to enable Automatic Torrent Management for each torrent.
   force_auto_tmm_ignore_tags: #Torrents with these tags will be ignored when force_auto_tmm is enabled.
     - cross-seed
-    - Upload 
+    - Upload
   tracker_error_tag: issue # Will set the tag of any torrents that do not have a working tracker.
   nohardlinks_tag: noHL # Will set the tag of any torrents with no hardlinks.
   share_limits_tag: ~share_limit # Will add this tag when applying share limits to provide an easy way to filter torrents by share limit group/priority for each torrent

--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -26,6 +26,9 @@ qbt:
 
 settings:
   force_auto_tmm: False # Will force qBittorrent to enable Automatic Torrent Management for each torrent.
+  force_auto_tmm_ignore_tags: #Torrents with these tags will be ignored when force_auto_tmm is enabled.
+    - cross-seed
+    - Upload
   tracker_error_tag: issue # Will set the tag of any torrents that do not have a working tracker.
   nohardlinks_tag: noHL # Will set the tag of any torrents with no hardlinks.
   share_limits_tag: ~share_limit # Will add this tag when applying share limits to provide an easy way to filter torrents by share limit group/priority for each torrent

--- a/modules/config.py
+++ b/modules/config.py
@@ -229,6 +229,9 @@ class Config:
             "cat_update_all": self.util.check_for_attribute(
                 self.data, "cat_update_all", parent="settings", var_type="bool", default=True
             ),
+            "force_auto_tmm_ignore_tags": self.util.check_for_attribute(
+                self.data, "force_auto_tmm_ignore_tags", parent="settings", var_type="list", default=[]
+            ),
         }
 
         self.tracker_error_tag = self.settings["tracker_error_tag"]
@@ -624,6 +627,8 @@ class Config:
                     raise Failed(err)
         else:
             if self.commands["share_limits"]:
+
+
                 err = "Config Error: share_limits. No valid grouping found."
                 self.notify(err, "Config")
                 raise Failed(err)

--- a/modules/config.py
+++ b/modules/config.py
@@ -229,6 +229,9 @@ class Config:
             "cat_update_all": self.util.check_for_attribute(
                 self.data, "cat_update_all", parent="settings", var_type="bool", default=True
             ),
+            "force_auto_tmm_ignore_tags": self.util.check_for_attribute(
+                self.data, "force_auto_tmm_ignore_tags", parent="settings", var_type="list", default=[]
+            ),
         }
 
         self.tracker_error_tag = self.settings["tracker_error_tag"]

--- a/modules/config.py
+++ b/modules/config.py
@@ -627,8 +627,6 @@ class Config:
                     raise Failed(err)
         else:
             if self.commands["share_limits"]:
-
-
                 err = "Config Error: share_limits. No valid grouping found."
                 self.notify(err, "Config")
                 raise Failed(err)

--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -99,6 +99,7 @@ class Qbt:
         self.get_category = cache(self.get_category)
         self.get_category_save_paths = cache(self.get_category_save_paths)
 
+
     def get_torrent_info(self):
         """
         Will create a 2D Dictionary with the torrent name as the key
@@ -125,7 +126,7 @@ class Qbt:
         logger.separator("Checking Settings", space=False, border=False)
         if settings["force_auto_tmm"]:
             logger.print_line(
-                "force_auto_tmm set to True. Will force Auto Torrent Management for all torrents.", self.config.loglevel
+                "force_auto_tmm set to True. Will force Auto Torrent Management for all torrents without matching force_auto_tmm_ignore_tags.", self.config.loglevel
             )
         logger.separator("Gathering Torrent Information", space=True, border=True)
         for torrent in self.torrent_list:
@@ -134,7 +135,11 @@ class Qbt:
             status = None
             working_tracker = None
             issue = {"potential": False}
-            if torrent.auto_tmm is False and settings["force_auto_tmm"] and torrent.category != "" and not self.config.dry_run:
+            if (torrent.auto_tmm is False and 
+                settings["force_auto_tmm"] and 
+                torrent.category != "" and 
+                not self.config.dry_run and 
+                not any(tag in torrent.tags for tag in self.config.settings.get("force_auto_tmm_ignore_tags", []))):
                 torrent.set_auto_management(True)
             try:
                 torrent_name = torrent.name

--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -125,7 +125,9 @@ class Qbt:
         logger.separator("Checking Settings", space=False, border=False)
         if settings["force_auto_tmm"]:
             logger.print_line(
-                "force_auto_tmm set to True. Will force Auto Torrent Management for all torrents.", self.config.loglevel
+                """force_auto_tmm set to True. Will force Auto Torrent Management
+                   for all torrents without matching force_auto_tmm_ignore_tags.""",
+                self.config.loglevel,
             )
         logger.separator("Gathering Torrent Information", space=True, border=True)
         for torrent in self.torrent_list:
@@ -134,7 +136,14 @@ class Qbt:
             status = None
             working_tracker = None
             issue = {"potential": False}
-            if torrent.auto_tmm is False and settings["force_auto_tmm"] and torrent.category != "" and not self.config.dry_run:
+            if (
+                torrent.auto_tmm is False
+                and settings["force_auto_tmm"]
+                and torrent.category != ""
+                and not self.config.dry_run
+                # check whether the torrent has a matching tag to ignore force_auto_tmm.
+                and not any(tag in torrent.tags for tag in self.config.settings.get("force_auto_tmm_ignore_tags", []))
+            ):
                 torrent.set_auto_management(True)
             try:
                 torrent_name = torrent.name

--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -125,7 +125,8 @@ class Qbt:
         logger.separator("Checking Settings", space=False, border=False)
         if settings["force_auto_tmm"]:
             logger.print_line(
-                "force_auto_tmm set to True. Will force Auto Torrent Management for all torrents without matching force_auto_tmm_ignore_tags.", self.config.loglevel
+                "force_auto_tmm set to True. Will force Auto Torrent Management for all torrents without matching force_auto_tmm_ignore_tags."
+                , self.config.loglevel
             )
         logger.separator("Gathering Torrent Information", space=True, border=True)
         for torrent in self.torrent_list:

--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -99,7 +99,6 @@ class Qbt:
         self.get_category = cache(self.get_category)
         self.get_category_save_paths = cache(self.get_category_save_paths)
 
-
     def get_torrent_info(self):
         """
         Will create a 2D Dictionary with the torrent name as the key

--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -141,6 +141,7 @@ class Qbt:
                 and settings["force_auto_tmm"]
                 and torrent.category != ""
                 and not self.config.dry_run
+                # check whether the torrent has a matching tag to ignore force_auto_tmm.
                 and not any(tag in torrent.tags for tag in self.config.settings.get("force_auto_tmm_ignore_tags", []))
             ):
                 torrent.set_auto_management(True)

--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -125,7 +125,8 @@ class Qbt:
         logger.separator("Checking Settings", space=False, border=False)
         if settings["force_auto_tmm"]:
             logger.print_line(
-                "force_auto_tmm set to True. Will force Auto Torrent Management for all torrents without matching force_auto_tmm_ignore_tags.", self.config.loglevel
+                "force_auto_tmm set to True. Will force Auto Torrent Management for all torrents without matching force_auto_tmm_ignore_tags.",
+                self.config.loglevel,
             )
         logger.separator("Gathering Torrent Information", space=True, border=True)
         for torrent in self.torrent_list:
@@ -134,11 +135,13 @@ class Qbt:
             status = None
             working_tracker = None
             issue = {"potential": False}
-            if (torrent.auto_tmm is False and 
-                settings["force_auto_tmm"] and 
-                torrent.category != "" and 
-                not self.config.dry_run and 
-                not any(tag in torrent.tags for tag in self.config.settings.get("force_auto_tmm_ignore_tags", []))):
+            if (
+                torrent.auto_tmm is False
+                and settings["force_auto_tmm"]
+                and torrent.category != ""
+                and not self.config.dry_run
+                and not any(tag in torrent.tags for tag in self.config.settings.get("force_auto_tmm_ignore_tags", []))
+            ):
                 torrent.set_auto_management(True)
             try:
                 torrent_name = torrent.name

--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -125,8 +125,8 @@ class Qbt:
         logger.separator("Checking Settings", space=False, border=False)
         if settings["force_auto_tmm"]:
             logger.print_line(
-                f"force_auto_tmm set to True. Will force Auto Torrent Management "
-                f"for all torrents without matching force_auto_tmm_ignore_tags.",
+                "force_auto_tmm set to True. Will force Auto Torrent Management "
+                "for all torrents without matching force_auto_tmm_ignore_tags.",
                 self.config.loglevel,
             )
         logger.separator("Gathering Torrent Information", space=True, border=True)

--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -126,8 +126,8 @@ class Qbt:
         if settings["force_auto_tmm"]:
             logger.print_line(
                 """force_auto_tmm set to True. Will force Auto Torrent Management
-                   for all torrents without matching force_auto_tmm_ignore_tags."""
-                , self.config.loglevel
+                   for all torrents without matching force_auto_tmm_ignore_tags.""",
+                self.config.loglevel,
             )
         logger.separator("Gathering Torrent Information", space=True, border=True)
         for torrent in self.torrent_list:
@@ -136,11 +136,13 @@ class Qbt:
             status = None
             working_tracker = None
             issue = {"potential": False}
-            if (torrent.auto_tmm is False and 
-                settings["force_auto_tmm"] and 
-                torrent.category != "" and 
-                not self.config.dry_run and 
-                not any(tag in torrent.tags for tag in self.config.settings.get("force_auto_tmm_ignore_tags", []))):
+            if (
+                torrent.auto_tmm is False
+                and settings["force_auto_tmm"]
+                and torrent.category != ""
+                and not self.config.dry_run
+                and not any(tag in torrent.tags for tag in self.config.settings.get("force_auto_tmm_ignore_tags", []))
+            ):
                 torrent.set_auto_management(True)
             try:
                 torrent_name = torrent.name

--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -125,7 +125,8 @@ class Qbt:
         logger.separator("Checking Settings", space=False, border=False)
         if settings["force_auto_tmm"]:
             logger.print_line(
-                "force_auto_tmm set to True. Will force Auto Torrent Management for all torrents without matching force_auto_tmm_ignore_tags."
+                """force_auto_tmm set to True. Will force Auto Torrent Management
+                   for all torrents without matching force_auto_tmm_ignore_tags."""
                 , self.config.loglevel
             )
         logger.separator("Gathering Torrent Information", space=True, border=True)

--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -125,8 +125,8 @@ class Qbt:
         logger.separator("Checking Settings", space=False, border=False)
         if settings["force_auto_tmm"]:
             logger.print_line(
-                """force_auto_tmm set to True. Will force Auto Torrent Management
-                   for all torrents without matching force_auto_tmm_ignore_tags.""",
+                f"force_auto_tmm set to True. Will force Auto Torrent Management "
+                f"for all torrents without matching force_auto_tmm_ignore_tags.",
                 self.config.loglevel,
             )
         logger.separator("Gathering Torrent Information", space=True, border=True)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description
Introduces a new configuration option 'force_auto_tmm_ignore_tags' that allows users to specify tags in the config which will prevent the force_auto_tmm feature from being applied to that torrent. This feature is meant to make qbit_manage more compatible with cross-seed v6 without having to completely disable auto_torrent_management.

Changes:

qbittorrent.py:
-  Modified the get_torrent_info method in the Qbt class.
-  Added a check for matching tags to ignore when applying force_auto_tmm

config.py:
- Added 'force_auto_tmm_ignore_tags' to the settings dictionary.
-  Implemented check_for_attribute method call to load the new setting from config.yml

config.yml:
- Added 'force_auto_tmm_ignore_tags' to the settings section. 
- Included example tags 'cross-seed' and 'Upload' as default values to ignore


Fixes # (issue)

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have modified this PR to merge to the develop branch
