### PR TITLE
Extend logging to explain why torrent files were not deleted.

### DIFF
--- a/modules/core/share_limits.py
+++ b/modules/core/share_limits.py
@@ -131,7 +131,13 @@ class ShareLimits:
                     if not self.config.dry_run:
                         self.qbt.tor_delete_recycle(torrent, attr)
                     body += logger.print_line(
-                        logger.insert_space("Deleted .torrent but NOT content files. Reason: path does not exist [path="+torrent["content_path"].replace(self.root_dir, self.remote_dir)+"].", 8), self.config.loglevel
+                        logger.insert_space(
+                            "Deleted .torrent but NOT content files. Reason: path does not exist [path="
+                            + torrent["content_path"].replace(self.root_dir, self.remote_dir)
+                            + "].",
+                            8,
+                        ),
+                        self.config.loglevel,
                     )
                 attr["body"] = "\n".join(body)
                 if not group_notifications:

--- a/modules/core/share_limits.py
+++ b/modules/core/share_limits.py
@@ -112,7 +112,7 @@ class ShareLimits:
                         if not self.config.dry_run:
                             self.qbt.tor_delete_recycle(torrent, attr)
                         body += logger.print_line(
-                            logger.insert_space("Deleted .torrent but NOT content files.", 8),
+                            logger.insert_space("Deleted .torrent but NOT content files. Reason: is cross-seed", 8),
                             self.config.loglevel,
                         )
                     else:
@@ -131,7 +131,7 @@ class ShareLimits:
                     if not self.config.dry_run:
                         self.qbt.tor_delete_recycle(torrent, attr)
                     body += logger.print_line(
-                        logger.insert_space("Deleted .torrent but NOT content files.", 8), self.config.loglevel
+                        logger.insert_space("Deleted .torrent but NOT content files. Reason: path does not exist [path="+torrent["content_path"].replace(self.root_dir, self.remote_dir)+"].", 8), self.config.loglevel
                     )
                 attr["body"] = "\n".join(body)
                 if not group_notifications:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

When cleanup deletes a torrent, sometimes the contents are not deleted. The reason for this can be twofold: it is a cross-seed OR the path cannot be resolved. This PR extends the logging such that users can more easily debug their config.

Fixes #625

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [X] I have modified this PR to merge to the develop branch
