### PR TITLE
(chore): don't dependabot master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,15 +12,6 @@ updates:
     target-branch: "develop"
     assignees:
       - "bobokun"
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "master"
-    assignees:
-      - "bobokun"
-    allow:
-      - dependency-name: "qbittorrent-api"
   - package-ecosystem: github-actions
     directory: '/'
     schedule:


### PR DESCRIPTION
Master does not have releases cut automatically thus any commits to master are confusing as they are not available to users

Currently the readme states master supports qbit 4.6.6 but this is incorrect as the last release fails to include this bump 