### PR TITLE
Add config option to remove tags injected from cross-seed

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -34,7 +34,7 @@ COMMANDS = [
     "skip_cleanup",
     "skip_qb_version_check",
     "dry_run",
-    "rem_cross_seed_tags"
+    "rem_cross_seed_tags",
 ]
 
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -34,6 +34,7 @@ COMMANDS = [
     "skip_cleanup",
     "skip_qb_version_check",
     "dry_run",
+    "rem_cross_seed_tags"
 ]
 
 

--- a/modules/core/remove_cross_seed_tags.py
+++ b/modules/core/remove_cross_seed_tags.py
@@ -11,12 +11,11 @@ class RemoveCrossSeedTags:
         self.stats_removed = 0
 
         self.torrents_updated = []  # List of torrents with tags removed
-        self.notify_attr = []  # List of single torrent attributes to send to notifiarr
 
         self.rem_cross_seed_tags()
 
     def rem_cross_seed_tags(self):
-        """Move torrents from cross seed directory to correct save directory."""
+        """Remove cross-seed tag from torrents"""
         logger.separator("Removing cross-seed tag from Torrents", space=False, border=False)
 
         logger.print_line("Checking for torrents with cross-seed tag")

--- a/modules/core/remove_cross_seed_tags.py
+++ b/modules/core/remove_cross_seed_tags.py
@@ -1,0 +1,40 @@
+from modules import util
+
+logger = util.logger
+
+
+class RemoveCrossSeedTags:
+    def __init__(self, qbit_manager):
+        self.qbt = qbit_manager
+        self.config = qbit_manager.config
+        self.client = qbit_manager.client
+        self.stats_removed = 0
+
+        self.torrents_updated = []  # List of torrents with tags removed
+        self.notify_attr = []  # List of single torrent attributes to send to notifiarr
+
+        self.rem_cross_seed_tags()
+
+    def rem_cross_seed_tags(self):
+        """Move torrents from cross seed directory to correct save directory."""
+        logger.separator("Removing cross-seed tag from Torrents", space=False, border=False)
+
+        logger.print_line("Checking for torrents with cross-seed tag")
+        torrents_list = self.qbt.get_torrents({"sort": "added_on", "reverse": True})
+
+        for torrent in torrents_list:
+            torrent_tags = torrent.tags.split(", ")
+            if 'cross-seed' in torrent_tags:
+                torrent.remove_tags(tags='cross-seed')
+                self.torrents_updated.append(torrent.name)
+                self.stats_removed +=1 
+
+        if self.stats_removed >= 1:
+            logger.print_line(
+                f"{'Did not remove' if self.config.dry_run else 'Removed'} {self.stats_removed} torrents with cross-seed tag.", self.config.loglevel
+            )
+        else:
+            logger.print_line("No new torrents to update.", self.config.loglevel)
+
+
+

--- a/modules/core/remove_cross_seed_tags.py
+++ b/modules/core/remove_cross_seed_tags.py
@@ -24,17 +24,15 @@ class RemoveCrossSeedTags:
 
         for torrent in torrents_list:
             torrent_tags = torrent.tags.split(", ")
-            if 'cross-seed' in torrent_tags:
-                torrent.remove_tags(tags='cross-seed')
+            if "cross-seed" in torrent_tags:
+                torrent.remove_tags(tags="cross-seed")
                 self.torrents_updated.append(torrent.name)
-                self.stats_removed +=1 
+                self.stats_removed += 1
 
         if self.stats_removed >= 1:
             logger.print_line(
-                f"{'Did not remove' if self.config.dry_run else 'Removed'} {self.stats_removed} torrents with cross-seed tag.", self.config.loglevel
+                f"{'Did not remove' if self.config.dry_run else 'Removed'} {self.stats_removed} torrents with cross-seed tag.",
+                self.config.loglevel,
             )
         else:
             logger.print_line("No new torrents to update.", self.config.loglevel)
-
-
-

--- a/qbit_manage.py
+++ b/qbit_manage.py
@@ -371,8 +371,8 @@ util.logger = logger
 from modules.config import Config  # noqa
 from modules.core.category import Category  # noqa
 from modules.core.cross_seed import CrossSeed  # noqa
-from modules.core.remove_cross_seed_tags import RemoveCrossSeedTags  # noqa
 from modules.core.recheck import ReCheck  # noqa
+from modules.core.remove_cross_seed_tags import RemoveCrossSeedTags  # noqa
 from modules.core.remove_orphaned import RemoveOrphaned  # noqa
 from modules.core.remove_unregistered import RemoveUnregistered  # noqa
 from modules.core.share_limits import ShareLimits  # noqa

--- a/qbit_manage.py
+++ b/qbit_manage.py
@@ -371,6 +371,7 @@ util.logger = logger
 from modules.config import Config  # noqa
 from modules.core.category import Category  # noqa
 from modules.core.cross_seed import CrossSeed  # noqa
+from modules.core.remove_cross_seed_tags import RemoveCrossSeedTags  # noqa
 from modules.core.recheck import ReCheck  # noqa
 from modules.core.remove_orphaned import RemoveOrphaned  # noqa
 from modules.core.remove_unregistered import RemoveUnregistered  # noqa
@@ -496,6 +497,10 @@ def start():
         # Set Tags
         if cfg.commands["tag_update"]:
             stats["tagged"] += Tags(qbit_manager).stats
+
+        # Remove cross-seed tags
+        if cfg.commands["rem_cross_seed_tags"]:
+            RemoveCrossSeedTags(qbit_manager)
 
         # Set Cross Seed
         if cfg.commands["cross_seed"]:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

I added an option to remove cross-seed tags from torrents injected by cross-seed, since cross-seed adds these tags by default on torrents and (if you have the duplicateCategories option enabled in cross-seed), it sets the category to e.g movies.cross-seed. There's currently no option to customize or remove the tag. For me I would just need the category set for cross seeded torrents and don't need the tag. This helps with decluttering unneeded tags. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have modified this PR to merge to the develop branch
