### PR TITLE
(fix): BHD add additional unregistered messages for season packs

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-4.1.15-develop1
+4.1.15-develop2

--- a/modules/util.py
+++ b/modules/util.py
@@ -91,6 +91,9 @@ class TorrentMessages:
         "OTHER",
         "TORRENT HAS BEEN DELETED",
         "NUKED",
+        "SEASON PACK:",
+        "SEASON PACK OUT",
+        "SEASON PACK UPLOADED",
     ]
 
     IGNORE_MSGS = [


### PR DESCRIPTION
title


3 torrents tagged with "issue" but are actually unregistered