### PR TITLE
(fix): don't reapply tags every run when torrent

### DIFF
--- a/modules/core/tags.py
+++ b/modules/core/tags.py
@@ -41,7 +41,11 @@ class Tags:
             if (
                 torrent.tags == ""
                 or not util.is_tag_in_torrent(tracker["tag"], torrent.tags)
-                or (torrent.state == "stalledDL" and not util.is_tag_in_torrent(self.stalled_tag, torrent.tags))
+                or (
+                    self.tag_stalled_torrents
+                    and torrent.state == "stalledDL"
+                    and not util.is_tag_in_torrent(self.stalled_tag, torrent.tags)
+                )
             ):
                 stalled = False
                 if self.tag_stalled_torrents and torrent.state == "stalledDL":


### PR DESCRIPTION
is stalled but tag_stalled_torrents is set to false

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

If `tag_stalled_torrents` is set to `false` and a torrent is stalled, already correctly tagged torrents are getting their tags re-applied each time we run `qbit_manage`.

**Reason**
Condition checks only for stalled torrent and if stalled tag is applied, but does not check if `tag_stalled_torrents: true`.

**Fix**
This fix adds the check for `tag_stalled_torrents: true`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have modified this PR to merge to the develop branch
