### PR TITLE
Fixed: BHD 'Season Pack:' message not detected as unregistered

### DIFF
--- a/modules/util.py
+++ b/modules/util.py
@@ -364,7 +364,7 @@ class TorrentMessages:
         "OTHER",
         "TORRENT HAS BEEN DELETED",
         "NUKED",
-        "SEASON PACK:",
+        "SEASON PACK",
         "SEASON PACK OUT",
         "SEASON PACK UPLOADED",
     ]


### PR DESCRIPTION
## Summary

BHD torrents with tracker message `Season Pack: https://beyond-hd.me/details/...` were not being detected as unregistered and removed.

## Root Cause

The `check_for_unregistered_torrents_in_bhd` function in `remove_unregistered.py` strips the colon from tracker messages before checking:

```python
status_filtered = msg_up.split(":")[0]  # "SEASON PACK: ..." becomes "SEASON PACK"
```

However, the pattern list in `UNREGISTERED_MSGS_BHD` had `"SEASON PACK:"` (with colon), which would never match the filtered text `"SEASON PACK"` (without colon).

## Fix

Remove the trailing colon from the pattern: `"SEASON PACK:"` → `"SEASON PACK"`

This is consistent with how `"TRUMPED"` (not `"TRUMPED:"`) is already defined in the list.

## Testing

```python
# Before fix:
>>> status_filtered = "SEASON PACK: https://...".upper().split(":")[0]
>>> list_in_text(status_filtered, TorrentMessages.UNREGISTERED_MSGS_BHD)
False  # BUG

# After fix:
>>> list_in_text(status_filtered, TorrentMessages.UNREGISTERED_MSGS_BHD)
True  # FIXED
```

## Impact

BHD torrents that should be removed (because a season pack exists) will now be correctly detected and removed by `rem_unregistered`.