### PR TITLE
Fix active downloads marked orphaned when qBit uses separate incomplete dir

### DIFF
--- a/modules/core/remove_orphaned.py
+++ b/modules/core/remove_orphaned.py
@@ -265,21 +265,13 @@ class RemoveOrphaned:
         # Use download_path for incomplete torrents so that files actively
         # downloading to a separate directory are not incorrectly flagged as
         # orphans.
-        if (
-            not torrent.state_enum.is_complete
-            and torrent.get("download_path", "")
-        ):
+        if not torrent.state_enum.is_complete and torrent.get("download_path", ""):
             base_path = torrent["download_path"]
         else:
             base_path = torrent.save_path
 
         # Use list comprehension for better performance with cross-platform
         # path normalization
-        fullpath_torrent_files = [
-            os.path.normpath(
-                os.path.join(base_path, file.name)
-            )
-            for file in torrent.files
-        ]
+        fullpath_torrent_files = [os.path.normpath(os.path.join(base_path, file.name)) for file in torrent.files]
 
         return fullpath_torrent_files


### PR DESCRIPTION
## Description

When the user has qBittorrent set to keep incomplete downloads in a particular location, a torrent's save_path does not match its download_path and therefore gets marked as an orphan. 

I fixed this by using `torrent["download_path"]` if `not torrent.state_enum.is_complete`.

Fixes #1115

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have modified this PR to merge to the develop branch
