### PR TITLE
feat: add global_options for nohardlinks config

### DIFF
--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -145,7 +145,7 @@ nohardlinks:
   # Mandatory to fill out directory parameter above to use this function (root_dir/remote_dir)
   # This variable should be set to your category name of your completed movies/completed series in qbit. Acceptable variable can be any category you would like to tag if there are no hardlinks found
   # <OPTIONAL> global_options: Set default exclude_tags and ignore_root_dir for all categories.
-  # Per-category exclude_tags are merged with global (union). Per-category ignore_root_dir overrides global.
+  # Per-category values override global when set. Categories without the option inherit the global default.
   global_options:
     exclude_tags:
       - AnimeBytes
@@ -154,13 +154,13 @@ nohardlinks:
   series-completed-4k:
   movies-completed:
     # <OPTIONAL> exclude_tags var: Will exclude torrents with any of the following tags when searching through the category.
-    # These are merged with global_options exclude_tags.
+    # Overrides global_options exclude_tags when set.
     exclude_tags:
       - Beyond-HD
       - AnimeBytes
       - MaM
     # <OPTIONAL> ignore_root_dir var: Will ignore any hardlinks detected in the same root_dir.
-    # Overrides global_options ignore_root_dir if set.
+    # Overrides global_options ignore_root_dir when set.
     ignore_root_dir: true
   # Can have additional categories set with separate ratio/seeding times defined.
   series-completed:

--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -144,15 +144,23 @@ nohardlinks:
   # Tag Movies/Series that are not hard linked outside the root directory
   # Mandatory to fill out directory parameter above to use this function (root_dir/remote_dir)
   # This variable should be set to your category name of your completed movies/completed series in qbit. Acceptable variable can be any category you would like to tag if there are no hardlinks found
+  # <OPTIONAL> global_options: Set default exclude_tags and ignore_root_dir for all categories.
+  # Per-category exclude_tags are merged with global (union). Per-category ignore_root_dir overrides global.
+  global_options:
+    exclude_tags:
+      - AnimeBytes
+    ignore_root_dir: true
   movies-completed-4k:
   series-completed-4k:
   movies-completed:
     # <OPTIONAL> exclude_tags var: Will exclude torrents with any of the following tags when searching through the category.
+    # These are merged with global_options exclude_tags.
     exclude_tags:
       - Beyond-HD
       - AnimeBytes
       - MaM
-    # <OPTIONAL> ignore_root_dir var: Will ignore any hardlinks detected in the same root_dir (Default True).
+    # <OPTIONAL> ignore_root_dir var: Will ignore any hardlinks detected in the same root_dir.
+    # Overrides global_options ignore_root_dir if set.
     ignore_root_dir: true
   # Can have additional categories set with separate ratio/seeding times defined.
   series-completed:
@@ -160,7 +168,7 @@ nohardlinks:
     exclude_tags:
       - Beyond-HD
       - BroadcasTheNet
-    # <OPTIONAL> ignore_root_dir var: Will ignore any hardlinks detected in the same root_dir (Default True).
+    # <OPTIONAL> ignore_root_dir var: Will ignore any hardlinks detected in the same root_dir.
     ignore_root_dir: true
 
 share_limits:

--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -144,8 +144,10 @@ nohardlinks:
   # Tag Movies/Series that are not hard linked outside the root directory
   # Mandatory to fill out directory parameter above to use this function (root_dir/remote_dir)
   # This variable should be set to your category name of your completed movies/completed series in qbit. Acceptable variable can be any category you would like to tag if there are no hardlinks found
-  # <OPTIONAL> global_options: Set default exclude_tags and ignore_root_dir for all categories.
-  # Per-category values override global when set. Categories without the option inherit the global default.
+  # <OPTIONAL> global_options: Set defaults for all categories.
+  # - exclude_tags: per-category list is MERGED (union) with the global list.
+  # - ignore_root_dir: per-category value OVERRIDES the global value when set.
+  # Categories without the option inherit the global default.
   global_options:
     exclude_tags:
       - AnimeBytes
@@ -154,10 +156,9 @@ nohardlinks:
   series-completed-4k:
   movies-completed:
     # <OPTIONAL> exclude_tags var: Will exclude torrents with any of the following tags when searching through the category.
-    # Overrides global_options exclude_tags when set.
+    # Merged (union) with global_options exclude_tags. Effective set here: [AnimeBytes, Beyond-HD, MaM].
     exclude_tags:
       - Beyond-HD
-      - AnimeBytes
       - MaM
     # <OPTIONAL> ignore_root_dir var: Will ignore any hardlinks detected in the same root_dir.
     # Overrides global_options ignore_root_dir when set.

--- a/docs/Config-Setup.md
+++ b/docs/Config-Setup.md
@@ -268,6 +268,24 @@ Note that `ignore_root_dir` (Default: True) will ignore any hardlinks detected i
 | `exclude_tags`    | List of tags to exclude from the check. Torrents with any of these tags will not be processed. This is useful to exclude certain trackers from being scanned for hardlinking purposes | None           | <center>❌</center> |
 | `ignore_root_dir` | Ignore any hardlinks detected in the same [root_dir](#directory)                                                                                                                      | True           | <center>❌</center> |
 
+### Global Options
+
+You can set default `exclude_tags` and `ignore_root_dir` for all categories using the optional `global_options` key. Per-category values **override** the global default when set. Categories without the option inherit the global default.
+
+```yaml
+nohardlinks:
+  global_options:
+    exclude_tags:
+      - AnimeBytes
+    ignore_root_dir: true
+  movies-completed-4k:        # inherits: exclude_tags=[AnimeBytes], ignore_root_dir=true
+  movies-completed:
+    exclude_tags:              # overrides global: only [Beyond-HD, MaM]
+      - Beyond-HD
+      - MaM
+    ignore_root_dir: false     # overrides global
+```
+
 ## **share_limits:**
 
 Control how torrent share limits are set depending on the priority of your grouping. This can apply a max ratio, seed time limits to your torrents or limit your torrent upload speed as well. Each torrent will be matched with the share limit group with the highest priority that meets the group filter criteria. Each torrent can only be matched with one share limit group.

--- a/docs/Config-Setup.md
+++ b/docs/Config-Setup.md
@@ -270,7 +270,10 @@ Note that `ignore_root_dir` (Default: True) will ignore any hardlinks detected i
 
 ### Global Options
 
-You can set default `exclude_tags` and `ignore_root_dir` for all categories using the optional `global_options` key. Per-category values **override** the global default when set. Categories without the option inherit the global default.
+You can set defaults for all categories using the optional `global_options` key, with these merge semantics:
+
+- **`exclude_tags`** — per-category list is **merged (union)** with the global list. A category-level `exclude_tags` adds to the global set, it does not replace it.
+- **`ignore_root_dir`** — per-category boolean **overrides** the global value when set. Categories without the key inherit the global default.
 
 ```yaml
 nohardlinks:
@@ -280,10 +283,10 @@ nohardlinks:
     ignore_root_dir: true
   movies-completed-4k:        # inherits: exclude_tags=[AnimeBytes], ignore_root_dir=true
   movies-completed:
-    exclude_tags:              # overrides global: only [Beyond-HD, MaM]
+    exclude_tags:              # merged with global → [AnimeBytes, Beyond-HD, MaM]
       - Beyond-HD
       - MaM
-    ignore_root_dir: false     # overrides global
+    ignore_root_dir: false     # overrides global → false
 ```
 
 ## **share_limits:**

--- a/modules/config.py
+++ b/modules/config.py
@@ -516,20 +516,38 @@ class Config:
         self.nohardlinks = None
         if "nohardlinks" in self.data and self.commands["tag_nohardlinks"] and self.data["nohardlinks"] is not None:
             self.nohardlinks = {}
-            for cat in self.data["nohardlinks"]:
-                if isinstance(self.data["nohardlinks"], list) and isinstance(cat, str):
-                    self.nohardlinks[cat] = {"exclude_tags": [], "ignore_root_dir": True}
+            nohardlinks_data = self.data["nohardlinks"]
+            # Extract global_options defaults if present
+            global_opts = {}
+            if isinstance(nohardlinks_data, dict):
+                global_opts = nohardlinks_data.get("global_options", {}) or {}
+            global_exclude_tags = global_opts.get("exclude_tags", []) or []
+            global_ignore_root_dir = global_opts.get("ignore_root_dir", True)
+            for cat in nohardlinks_data:
+                if cat == "global_options":
+                    continue
+                if isinstance(nohardlinks_data, list) and isinstance(cat, str):
+                    self.nohardlinks[cat] = {
+                        "exclude_tags": list(global_exclude_tags),
+                        "ignore_root_dir": global_ignore_root_dir,
+                    }
                     continue
                 if isinstance(cat, dict):
                     cat_str = list(cat.keys())[0]
                 elif isinstance(cat, str):
                     cat_str = cat
-                    cat = self.data["nohardlinks"]
+                    cat = nohardlinks_data
                 if cat[cat_str] is None:
                     cat[cat_str] = {}
+                cat_exclude_tags = cat[cat_str].get("exclude_tags", None)
+                cat_ignore_root_dir = cat[cat_str].get("ignore_root_dir", None)
+                # Merge: category-level exclude_tags extend global, ignore_root_dir overrides global
+                merged_exclude_tags = list(global_exclude_tags)
+                if cat_exclude_tags:
+                    merged_exclude_tags = list(set(merged_exclude_tags + cat_exclude_tags))
                 self.nohardlinks[cat_str] = {
-                    "exclude_tags": cat[cat_str].get("exclude_tags", []),
-                    "ignore_root_dir": cat[cat_str].get("ignore_root_dir", True),
+                    "exclude_tags": merged_exclude_tags,
+                    "ignore_root_dir": cat_ignore_root_dir if cat_ignore_root_dir is not None else global_ignore_root_dir,
                 }
                 if self.nohardlinks[cat_str]["exclude_tags"] is None:
                     self.nohardlinks[cat_str]["exclude_tags"] = []

--- a/modules/config.py
+++ b/modules/config.py
@@ -520,7 +520,12 @@ class Config:
             # Extract global_options defaults if present
             global_opts = {}
             if isinstance(nohardlinks_data, dict):
-                global_opts = nohardlinks_data.get("global_options", {}) or {}
+                raw_global_opts = nohardlinks_data.get("global_options", {}) or {}
+                if not isinstance(raw_global_opts, dict):
+                    err = f"Config Error: nohardlinks global_options must be a dict (got {type(raw_global_opts).__name__})"
+                    self.notify(err, "Config")
+                    raise Failed(err)
+                global_opts = raw_global_opts
             global_exclude_tags = global_opts.get("exclude_tags", []) or []
             global_ignore_root_dir = global_opts.get("ignore_root_dir", True)
             for cat in nohardlinks_data:
@@ -548,7 +553,11 @@ class Config:
                         err = f"Config Error: nohardlinks category {cat_str} attribute exclude_tags must be a list"
                         self.notify(err, "Config")
                         raise Failed(err)
-                    merged_exclude_tags = list(set(merged_exclude_tags) | set(cat_exclude_tags))
+                    seen: set[str] = set(merged_exclude_tags)
+                    for _tag in cat_exclude_tags:
+                        if _tag not in seen:
+                            seen.add(_tag)
+                            merged_exclude_tags.append(_tag)
                 self.nohardlinks[cat_str] = {
                     "exclude_tags": merged_exclude_tags,
                     "ignore_root_dir": cat_ignore_root_dir if cat_ignore_root_dir is not None else global_ignore_root_dir,
@@ -559,7 +568,7 @@ class Config:
                     raise Failed(err)
         else:
             if self.commands["tag_nohardlinks"]:
-                err = "Config Error: nohardlinks must be a dict with categories and optional global_options"
+                err = "Config Error: nohardlinks must be a dict (with optional global_options) or a list of category names/dicts"
                 self.notify(err, "Config")
                 raise Failed(err)
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -567,6 +567,10 @@ class Config:
                     self.notify(err, "Config")
                     raise Failed(err)
             global_ignore_root_dir = global_opts.get("ignore_root_dir", True)
+            if not isinstance(global_ignore_root_dir, bool):
+                err = "Config Error: nohardlinks global_options ignore_root_dir must be a boolean type"
+                self.notify(err, "Config")
+                raise Failed(err)
             for cat in nohardlinks_data:
                 # Only the dict-form `nohardlinks: {global_options: {...}}` reserves this key.
                 # In list-form, a category legitimately named "global_options" must not be

--- a/modules/config.py
+++ b/modules/config.py
@@ -517,7 +517,15 @@ class Config:
         if "nohardlinks" in self.data and self.commands["tag_nohardlinks"] and self.data["nohardlinks"] is not None:
             self.nohardlinks = {}
             nohardlinks_data = self.data["nohardlinks"]
-            # Extract global_options defaults if present
+            # Bug 1 fix: validate outer container type before iterating
+            if not isinstance(nohardlinks_data, (dict, list)):
+                err = (
+                    f"Config Error: nohardlinks must be a dict (with optional global_options) or a list of category "
+                    f"names/dicts (got {type(nohardlinks_data).__name__})"
+                )
+                self.notify(err, "Config")
+                raise Failed(err)
+            # Extract global_options defaults if present (dict form or list-with-global_options-entry form)
             global_opts = {}
             if isinstance(nohardlinks_data, dict):
                 raw_global_opts = nohardlinks_data.get("global_options", {}) or {}
@@ -526,10 +534,34 @@ class Config:
                     self.notify(err, "Config")
                     raise Failed(err)
                 global_opts = raw_global_opts
+            elif isinstance(nohardlinks_data, list):
+                # Bug 3 fix: extract global_options from list-form when present as a dict entry
+                for _entry in nohardlinks_data:
+                    if isinstance(_entry, dict) and "global_options" in _entry:
+                        raw_global_opts = _entry["global_options"] or {}
+                        if not isinstance(raw_global_opts, dict):
+                            err = (
+                                f"Config Error: nohardlinks global_options must be a dict (got {type(raw_global_opts).__name__})"
+                            )
+                            self.notify(err, "Config")
+                            raise Failed(err)
+                        global_opts = raw_global_opts
+                        break
             global_exclude_tags = global_opts.get("exclude_tags", []) or []
+            # Bug 2 fix: validate global exclude_tags is a list
+            if not isinstance(global_exclude_tags, list):
+                err = (
+                    f"Config Error: nohardlinks global_options exclude_tags must be a list"
+                    f" (got {type(global_exclude_tags).__name__})"
+                )
+                self.notify(err, "Config")
+                raise Failed(err)
             global_ignore_root_dir = global_opts.get("ignore_root_dir", True)
             for cat in nohardlinks_data:
                 if cat == "global_options":
+                    continue
+                # Bug 3 fix: skip the global_options dict entry when iterating a list-form nohardlinks
+                if isinstance(nohardlinks_data, list) and isinstance(cat, dict) and "global_options" in cat:
                     continue
                 if isinstance(nohardlinks_data, list) and isinstance(cat, str):
                     self.nohardlinks[cat] = {

--- a/modules/config.py
+++ b/modules/config.py
@@ -556,9 +556,22 @@ class Config:
                 )
                 self.notify(err, "Config")
                 raise Failed(err)
+            # Entries must be strings — a non-string (e.g. nested list/dict) would raise an
+            # unhashable-type TypeError in the per-category dedup below instead of a clear error.
+            for _tag in global_exclude_tags:
+                if not isinstance(_tag, str):
+                    err = (
+                        f"Config Error: nohardlinks global_options exclude_tags entries must be strings"
+                        f" (got {type(_tag).__name__})"
+                    )
+                    self.notify(err, "Config")
+                    raise Failed(err)
             global_ignore_root_dir = global_opts.get("ignore_root_dir", True)
             for cat in nohardlinks_data:
-                if cat == "global_options":
+                # Only the dict-form `nohardlinks: {global_options: {...}}` reserves this key.
+                # In list-form, a category legitimately named "global_options" must not be
+                # silently dropped (the list-form global entry is the dict-item case below).
+                if isinstance(nohardlinks_data, dict) and cat == "global_options":
                     continue
                 # Bug 3 fix: skip the global_options dict entry when iterating a list-form nohardlinks
                 if isinstance(nohardlinks_data, list) and isinstance(cat, dict) and "global_options" in cat:
@@ -587,6 +600,13 @@ class Config:
                         raise Failed(err)
                     seen: set[str] = set(merged_exclude_tags)
                     for _tag in cat_exclude_tags:
+                        if not isinstance(_tag, str):
+                            err = (
+                                f"Config Error: nohardlinks category {cat_str} exclude_tags entries must be strings"
+                                f" (got {type(_tag).__name__})"
+                            )
+                            self.notify(err, "Config")
+                            raise Failed(err)
                         if _tag not in seen:
                             seen.add(_tag)
                             merged_exclude_tags.append(_tag)

--- a/modules/config.py
+++ b/modules/config.py
@@ -541,20 +541,25 @@ class Config:
                     cat[cat_str] = {}
                 cat_exclude_tags = cat[cat_str].get("exclude_tags", None)
                 cat_ignore_root_dir = cat[cat_str].get("ignore_root_dir", None)
-                # Per-category values override global when set, otherwise inherit global defaults
+                # Per-category exclude_tags merge (union) with global_options; ignore_root_dir overrides
+                merged_exclude_tags = list(global_exclude_tags)
+                if cat_exclude_tags is not None:
+                    if not isinstance(cat_exclude_tags, list):
+                        err = f"Config Error: nohardlinks category {cat_str} attribute exclude_tags must be a list"
+                        self.notify(err, "Config")
+                        raise Failed(err)
+                    merged_exclude_tags = list(set(merged_exclude_tags) | set(cat_exclude_tags))
                 self.nohardlinks[cat_str] = {
-                    "exclude_tags": cat_exclude_tags if cat_exclude_tags is not None else list(global_exclude_tags),
+                    "exclude_tags": merged_exclude_tags,
                     "ignore_root_dir": cat_ignore_root_dir if cat_ignore_root_dir is not None else global_ignore_root_dir,
                 }
-                if self.nohardlinks[cat_str]["exclude_tags"] is None:
-                    self.nohardlinks[cat_str]["exclude_tags"] = []
                 if not isinstance(self.nohardlinks[cat_str]["ignore_root_dir"], bool):
                     err = f"Config Error: nohardlinks category {cat_str} attribute ignore_root_dir must be a boolean type"
                     self.notify(err, "Config")
                     raise Failed(err)
         else:
             if self.commands["tag_nohardlinks"]:
-                err = "Config Error: nohardlinks must be a list of categories"
+                err = "Config Error: nohardlinks must be a dict with categories and optional global_options"
                 self.notify(err, "Config")
                 raise Failed(err)
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -528,7 +528,9 @@ class Config:
             # Extract global_options defaults if present (dict form or list-with-global_options-entry form)
             global_opts = {}
             if isinstance(nohardlinks_data, dict):
-                raw_global_opts = nohardlinks_data.get("global_options", {}) or {}
+                raw_global_opts = nohardlinks_data.get("global_options", {})
+                if raw_global_opts is None:
+                    raw_global_opts = {}
                 if not isinstance(raw_global_opts, dict):
                     err = f"Config Error: nohardlinks global_options must be a dict (got {type(raw_global_opts).__name__})"
                     self.notify(err, "Config")
@@ -538,7 +540,9 @@ class Config:
                 # Bug 3 fix: extract global_options from list-form when present as a dict entry
                 for _entry in nohardlinks_data:
                     if isinstance(_entry, dict) and "global_options" in _entry:
-                        raw_global_opts = _entry["global_options"] or {}
+                        raw_global_opts = _entry["global_options"]
+                        if raw_global_opts is None:
+                            raw_global_opts = {}
                         if not isinstance(raw_global_opts, dict):
                             err = (
                                 f"Config Error: nohardlinks global_options must be a dict (got {type(raw_global_opts).__name__})"
@@ -547,7 +551,9 @@ class Config:
                             raise Failed(err)
                         global_opts = raw_global_opts
                         break
-            global_exclude_tags = global_opts.get("exclude_tags", []) or []
+            global_exclude_tags = global_opts.get("exclude_tags", [])
+            if global_exclude_tags is None:
+                global_exclude_tags = []
             # Bug 2 fix: validate global exclude_tags is a list
             if not isinstance(global_exclude_tags, list):
                 err = (
@@ -566,6 +572,7 @@ class Config:
                     )
                     self.notify(err, "Config")
                     raise Failed(err)
+            global_exclude_tags = list(dict.fromkeys(global_exclude_tags))
             global_ignore_root_dir = global_opts.get("ignore_root_dir", True)
             if not isinstance(global_ignore_root_dir, bool):
                 err = "Config Error: nohardlinks global_options ignore_root_dir must be a boolean type"

--- a/modules/config.py
+++ b/modules/config.py
@@ -541,12 +541,9 @@ class Config:
                     cat[cat_str] = {}
                 cat_exclude_tags = cat[cat_str].get("exclude_tags", None)
                 cat_ignore_root_dir = cat[cat_str].get("ignore_root_dir", None)
-                # Merge: category-level exclude_tags extend global, ignore_root_dir overrides global
-                merged_exclude_tags = list(global_exclude_tags)
-                if cat_exclude_tags:
-                    merged_exclude_tags = list(set(merged_exclude_tags + cat_exclude_tags))
+                # Per-category values override global when set, otherwise inherit global defaults
                 self.nohardlinks[cat_str] = {
-                    "exclude_tags": merged_exclude_tags,
+                    "exclude_tags": cat_exclude_tags if cat_exclude_tags is not None else list(global_exclude_tags),
                     "ignore_root_dir": cat_ignore_root_dir if cat_ignore_root_dir is not None else global_ignore_root_dir,
                 }
                 if self.nohardlinks[cat_str]["exclude_tags"] is None:

--- a/tests/test_nohardlinks_global_options.py
+++ b/tests/test_nohardlinks_global_options.py
@@ -1,54 +1,213 @@
-"""Unit tests for nohardlinks global_options merge behavior."""
+"""Unit tests for nohardlinks global_options merge behavior.
+
+These tests call ``Config.process_config_nohardlinks()`` directly via
+``object.__new__(Config)`` + attribute injection, mirroring the
+``make_share_limits()`` pattern in factories.py.  Every assertion is tied to
+production code output — none of them are tautological self-assignment checks.
+"""
 
 from __future__ import annotations
 
-from tests.factories import FakeConfig
+import pytest
+
+from modules.config import Config
+from modules.util import Failed
+
+# ---------------------------------------------------------------------------
+# Helper — minimal Config skeleton that satisfies process_config_nohardlinks
+# ---------------------------------------------------------------------------
 
 
-class TestNohardlinksGlobalOptions:
-    """Test nohardlinks global_options merge behavior for exclude_tags."""
+def _make_config(nohardlinks_data, *, tag_nohardlinks=True):
+    """Return a Config instance wired for process_config_nohardlinks().
 
-    def test_exclude_tags_merge_global_and_per_category(self):
-        """Per-category exclude_tags should merge (union) with global_options."""
-        cfg = FakeConfig()
-        cfg.nohardlinks = {
-            "category1": {"exclude_tags": ["tag1", "tag2", "tag3"], "ignore_root_dir": True},
-            "category2": {"exclude_tags": ["tag1", "tag2", "tag4"], "ignore_root_dir": True},
-        }
-        # Verify union happened: global [tag1, tag2] ∪ cat [tag3] and [tag1, tag4]
-        assert set(cfg.nohardlinks["category1"]["exclude_tags"]) == {"tag1", "tag2", "tag3"}
-        assert set(cfg.nohardlinks["category2"]["exclude_tags"]) == {"tag1", "tag2", "tag4"}
+    ``nohardlinks_data`` is the value that would sit under the ``nohardlinks``
+    key in config.yml.  ``tag_nohardlinks`` controls whether the command flag
+    is enabled (default True so the nohardlinks branch is exercised).
+    """
+    cfg = object.__new__(Config)
+    cfg.data = {"nohardlinks": nohardlinks_data}
+    cfg.commands = {"tag_nohardlinks": tag_nohardlinks}
+    cfg.notify_calls = []
+    cfg.notify = lambda err, func, *a, **kw: cfg.notify_calls.append((err, func))
+    return cfg
 
-    def test_exclude_tags_empty_per_category_inherits_global(self):
-        """Per-category without exclude_tags should inherit global."""
-        cfg = FakeConfig()
-        cfg.nohardlinks = {
-            "category1": {"exclude_tags": ["tag1", "tag2"], "ignore_root_dir": True},
-        }
-        assert set(cfg.nohardlinks["category1"]["exclude_tags"]) == {"tag1", "tag2"}
 
-    def test_exclude_tags_empty_global_per_category_specified(self):
-        """Per-category exclude_tags without global should work."""
-        cfg = FakeConfig()
-        cfg.nohardlinks = {
-            "category1": {"exclude_tags": ["tag1"], "ignore_root_dir": True},
-        }
-        assert set(cfg.nohardlinks["category1"]["exclude_tags"]) == {"tag1"}
+# ---------------------------------------------------------------------------
+# Order-preserving merge tests
+# ---------------------------------------------------------------------------
 
-    def test_exclude_tags_both_empty(self):
-        """Both global and per-category empty should result in empty list."""
-        cfg = FakeConfig()
-        cfg.nohardlinks = {
-            "category1": {"exclude_tags": [], "ignore_root_dir": True},
-        }
-        assert cfg.nohardlinks["category1"]["exclude_tags"] == []
 
-    def test_ignore_root_dir_override(self):
-        """Per-category ignore_root_dir should override global_options."""
-        cfg = FakeConfig()
-        cfg.nohardlinks = {
-            "category1": {"exclude_tags": [], "ignore_root_dir": False},
-            "category2": {"exclude_tags": [], "ignore_root_dir": True},
-        }
-        assert cfg.nohardlinks["category1"]["ignore_root_dir"] is False
-        assert cfg.nohardlinks["category2"]["ignore_root_dir"] is True
+class TestExcludeTagsMerge:
+    def test_global_and_per_cat_no_overlap(self):
+        """global=[a,b] + per_cat=[c] → [a,b,c], global tags appear first."""
+        cfg = _make_config(
+            {
+                "global_options": {"exclude_tags": ["a", "b"]},
+                "cat1": {"exclude_tags": ["c"]},
+            }
+        )
+        cfg.process_config_nohardlinks()
+        assert cfg.nohardlinks["cat1"]["exclude_tags"] == ["a", "b", "c"]
+
+    def test_global_and_per_cat_with_overlap(self):
+        """global=[a,b] + per_cat=[b,c] → [a,b,c], no duplicates, global-first."""
+        cfg = _make_config(
+            {
+                "global_options": {"exclude_tags": ["a", "b"]},
+                "cat1": {"exclude_tags": ["b", "c"]},
+            }
+        )
+        cfg.process_config_nohardlinks()
+        result = cfg.nohardlinks["cat1"]["exclude_tags"]
+        assert result == ["a", "b", "c"], f"Expected ['a','b','c'], got {result}"
+
+    def test_order_is_deterministic_global_first(self):
+        """Merge order: global tags always precede any extra per-cat tags."""
+        cfg = _make_config(
+            {
+                "global_options": {"exclude_tags": ["z", "y"]},
+                "cat1": {"exclude_tags": ["x", "y"]},
+            }
+        )
+        cfg.process_config_nohardlinks()
+        result = cfg.nohardlinks["cat1"]["exclude_tags"]
+        # z and y come from global, x is the only addition from per-cat
+        assert result[0] == "z"
+        assert result[1] == "y"
+        assert result[2] == "x"
+        assert len(result) == 3
+
+    def test_per_cat_no_exclude_tags_inherits_global(self):
+        """Category without exclude_tags gets global's list as-is."""
+        cfg = _make_config(
+            {
+                "global_options": {"exclude_tags": ["g1", "g2"]},
+                "cat1": {"ignore_root_dir": True},
+            }
+        )
+        cfg.process_config_nohardlinks()
+        assert cfg.nohardlinks["cat1"]["exclude_tags"] == ["g1", "g2"]
+
+    def test_empty_global_per_cat_specified(self):
+        """No global_options → per-cat exclude_tags used as-is."""
+        cfg = _make_config({"cat1": {"exclude_tags": ["only"]}})
+        cfg.process_config_nohardlinks()
+        assert cfg.nohardlinks["cat1"]["exclude_tags"] == ["only"]
+
+    def test_both_empty(self):
+        """Both global and per-cat empty → empty list."""
+        cfg = _make_config(
+            {
+                "global_options": {"exclude_tags": []},
+                "cat1": {"exclude_tags": []},
+            }
+        )
+        cfg.process_config_nohardlinks()
+        assert cfg.nohardlinks["cat1"]["exclude_tags"] == []
+
+    def test_multiple_categories_each_merged_independently(self):
+        """Each category gets its own independent merge; no cross-category bleed."""
+        cfg = _make_config(
+            {
+                "global_options": {"exclude_tags": ["global"]},
+                "cat1": {"exclude_tags": ["only_cat1"]},
+                "cat2": {"exclude_tags": ["only_cat2"]},
+            }
+        )
+        cfg.process_config_nohardlinks()
+        assert cfg.nohardlinks["cat1"]["exclude_tags"] == ["global", "only_cat1"]
+        assert cfg.nohardlinks["cat2"]["exclude_tags"] == ["global", "only_cat2"]
+
+
+# ---------------------------------------------------------------------------
+# ignore_root_dir override
+# ---------------------------------------------------------------------------
+
+
+class TestIgnoreRootDirOverride:
+    def test_per_cat_false_beats_global_true(self):
+        """Per-category ignore_root_dir=False overrides global default of True."""
+        cfg = _make_config(
+            {
+                "global_options": {"ignore_root_dir": True},
+                "cat1": {"ignore_root_dir": False},
+            }
+        )
+        cfg.process_config_nohardlinks()
+        assert cfg.nohardlinks["cat1"]["ignore_root_dir"] is False
+
+    def test_per_cat_true_beats_global_false(self):
+        """Per-category ignore_root_dir=True overrides global=False."""
+        cfg = _make_config(
+            {
+                "global_options": {"ignore_root_dir": False},
+                "cat1": {"ignore_root_dir": True},
+            }
+        )
+        cfg.process_config_nohardlinks()
+        assert cfg.nohardlinks["cat1"]["ignore_root_dir"] is True
+
+    def test_no_per_cat_inherits_global_ignore_root_dir(self):
+        """Category omitting ignore_root_dir inherits global value."""
+        cfg = _make_config(
+            {
+                "global_options": {"ignore_root_dir": False},
+                "cat1": {},
+            }
+        )
+        cfg.process_config_nohardlinks()
+        assert cfg.nohardlinks["cat1"]["ignore_root_dir"] is False
+
+
+# ---------------------------------------------------------------------------
+# global_options type validation (Bug 1)
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalOptionsTypeValidation:
+    def test_global_options_as_string_raises_failed(self):
+        """global_options: 'yes please' (string) must raise Failed."""
+        cfg = _make_config(
+            {
+                "global_options": "yes please",
+                "cat1": {},
+            }
+        )
+        with pytest.raises(Failed, match="global_options must be a dict"):
+            cfg.process_config_nohardlinks()
+
+    def test_global_options_as_list_raises_failed(self):
+        """global_options: [a, b] (list) must raise Failed."""
+        cfg = _make_config(
+            {
+                "global_options": ["a", "b"],
+                "cat1": {},
+            }
+        )
+        with pytest.raises(Failed, match="global_options must be a dict"):
+            cfg.process_config_nohardlinks()
+
+    def test_global_options_as_int_raises_failed(self):
+        """global_options: 42 (int) must raise Failed."""
+        cfg = _make_config(
+            {
+                "global_options": 42,
+                "cat1": {},
+            }
+        )
+        with pytest.raises(Failed, match="global_options must be a dict"):
+            cfg.process_config_nohardlinks()
+
+
+# ---------------------------------------------------------------------------
+# Per-category exclude_tags type validation (pre-existing, kept real)
+# ---------------------------------------------------------------------------
+
+
+class TestPerCatExcludeTagsTypeValidation:
+    def test_exclude_tags_as_string_raises_failed(self):
+        """Per-category exclude_tags as string must raise Failed."""
+        cfg = _make_config({"cat1": {"exclude_tags": "not-a-list"}})
+        with pytest.raises(Failed, match="exclude_tags must be a list"):
+            cfg.process_config_nohardlinks()

--- a/tests/test_nohardlinks_global_options.py
+++ b/tests/test_nohardlinks_global_options.py
@@ -211,3 +211,151 @@ class TestPerCatExcludeTagsTypeValidation:
         cfg = _make_config({"cat1": {"exclude_tags": "not-a-list"}})
         with pytest.raises(Failed, match="exclude_tags must be a list"):
             cfg.process_config_nohardlinks()
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — outer nohardlinks type validation
+# ---------------------------------------------------------------------------
+
+
+class TestOuterNohardlinksTypeValidation:
+    def test_nohardlinks_as_int_raises_failed(self):
+        """nohardlinks: 42 (int) must raise Failed before any iteration."""
+        cfg = _make_config(42)
+        with pytest.raises(Failed, match="nohardlinks must be a dict"):
+            cfg.process_config_nohardlinks()
+        # nohardlinks dict must NOT be populated with garbage
+        assert cfg.nohardlinks is None or cfg.nohardlinks == {}
+
+    def test_nohardlinks_as_string_raises_failed(self):
+        """nohardlinks: 'movies' (string) must raise Failed, not iterate characters."""
+        cfg = _make_config("movies-completed")
+        with pytest.raises(Failed, match="nohardlinks must be a dict"):
+            cfg.process_config_nohardlinks()
+
+    def test_nohardlinks_as_bool_raises_failed(self):
+        """nohardlinks: True (bool) must raise Failed."""
+        cfg = _make_config(True)
+        with pytest.raises(Failed, match="nohardlinks must be a dict"):
+            cfg.process_config_nohardlinks()
+
+    def test_nohardlinks_as_dict_is_valid(self):
+        """nohardlinks: {cat1: {}} (dict) must not raise."""
+        cfg = _make_config({"cat1": {}})
+        cfg.process_config_nohardlinks()
+        assert "cat1" in cfg.nohardlinks
+
+    def test_nohardlinks_as_list_is_valid(self):
+        """nohardlinks: [cat1] (list of strings) must not raise."""
+        cfg = _make_config(["movies-completed"])
+        cfg.process_config_nohardlinks()
+        assert "movies-completed" in cfg.nohardlinks
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 — global_options.exclude_tags type validation
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalExcludeTagsTypeValidation:
+    def test_global_exclude_tags_as_string_raises_failed(self):
+        """global_options: {exclude_tags: 'tag1'} (string) must raise Failed."""
+        cfg = _make_config(
+            {
+                "global_options": {"exclude_tags": "tag1"},
+                "cat1": {},
+            }
+        )
+        with pytest.raises(Failed, match="exclude_tags must be a list"):
+            cfg.process_config_nohardlinks()
+
+    def test_global_exclude_tags_as_int_raises_failed(self):
+        """global_options: {exclude_tags: 99} (int) must raise Failed."""
+        cfg = _make_config(
+            {
+                "global_options": {"exclude_tags": 99},
+                "cat1": {},
+            }
+        )
+        with pytest.raises(Failed, match="exclude_tags must be a list"):
+            cfg.process_config_nohardlinks()
+
+    def test_global_exclude_tags_as_list_is_valid(self):
+        """global_options: {exclude_tags: ['tag1']} (list) must not raise."""
+        cfg = _make_config(
+            {
+                "global_options": {"exclude_tags": ["tag1"]},
+                "cat1": {},
+            }
+        )
+        cfg.process_config_nohardlinks()
+        assert cfg.nohardlinks["cat1"]["exclude_tags"] == ["tag1"]
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 — legacy list-form inherits global_options
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyListInheritsGlobalOptions:
+    def test_list_of_strings_inherits_global_exclude_tags(self):
+        """Legacy list-of-strings entries must inherit global_options exclude_tags."""
+        cfg = _make_config(
+            [
+                {"global_options": {"exclude_tags": ["tracker1.example", "tracker2.example"]}},
+                "movies-completed",
+                "series-completed",
+            ]
+        )
+        cfg.process_config_nohardlinks()
+        assert cfg.nohardlinks["movies-completed"]["exclude_tags"] == ["tracker1.example", "tracker2.example"]
+        assert cfg.nohardlinks["series-completed"]["exclude_tags"] == ["tracker1.example", "tracker2.example"]
+        # global_options itself must NOT become a category key
+        assert "global_options" not in cfg.nohardlinks
+
+    def test_list_of_strings_inherits_global_ignore_root_dir(self):
+        """Legacy list-of-strings entries must inherit global_options ignore_root_dir."""
+        cfg = _make_config(
+            [
+                {"global_options": {"ignore_root_dir": False}},
+                "tv-series",
+            ]
+        )
+        cfg.process_config_nohardlinks()
+        assert cfg.nohardlinks["tv-series"]["ignore_root_dir"] is False
+
+    def test_list_of_strings_no_global_options_uses_defaults(self):
+        """Legacy list-of-strings without global_options gets default values."""
+        cfg = _make_config(["movies-completed"])
+        cfg.process_config_nohardlinks()
+        assert cfg.nohardlinks["movies-completed"]["exclude_tags"] == []
+        assert cfg.nohardlinks["movies-completed"]["ignore_root_dir"] is True
+
+    def test_list_of_dicts_inherits_global_exclude_tags(self):
+        """Legacy list-of-dicts entries must inherit global_options exclude_tags."""
+        cfg = _make_config(
+            [
+                {"global_options": {"exclude_tags": ["global-tag"]}},
+                {"Tv.Series": {"exclude_tags": ["local-tag"]}},
+            ]
+        )
+        cfg.process_config_nohardlinks()
+        result = cfg.nohardlinks["Tv.Series"]["exclude_tags"]
+        # global-tag comes first, local-tag appended
+        assert result == ["global-tag", "local-tag"], f"Expected ['global-tag', 'local-tag'], got {result}"
+        assert "global_options" not in cfg.nohardlinks
+
+    def test_list_of_dicts_inherits_global_ignore_root_dir(self):
+        """Legacy list-of-dicts entries inherit global ignore_root_dir unless overridden."""
+        cfg = _make_config(
+            [
+                {"global_options": {"ignore_root_dir": False}},
+                {"Tv.Series": {}},
+                {"Movies": {"ignore_root_dir": True}},
+            ]
+        )
+        cfg.process_config_nohardlinks()
+        # Tv.Series has no override → inherits global False
+        assert cfg.nohardlinks["Tv.Series"]["ignore_root_dir"] is False
+        # Movies explicitly sets True → overrides global False
+        assert cfg.nohardlinks["Movies"]["ignore_root_dir"] is True

--- a/tests/test_nohardlinks_global_options.py
+++ b/tests/test_nohardlinks_global_options.py
@@ -1,0 +1,54 @@
+"""Unit tests for nohardlinks global_options merge behavior."""
+
+from __future__ import annotations
+
+from tests.factories import FakeConfig
+
+
+class TestNohardlinksGlobalOptions:
+    """Test nohardlinks global_options merge behavior for exclude_tags."""
+
+    def test_exclude_tags_merge_global_and_per_category(self):
+        """Per-category exclude_tags should merge (union) with global_options."""
+        cfg = FakeConfig()
+        cfg.nohardlinks = {
+            "category1": {"exclude_tags": ["tag1", "tag2", "tag3"], "ignore_root_dir": True},
+            "category2": {"exclude_tags": ["tag1", "tag2", "tag4"], "ignore_root_dir": True},
+        }
+        # Verify union happened: global [tag1, tag2] ∪ cat [tag3] and [tag1, tag4]
+        assert set(cfg.nohardlinks["category1"]["exclude_tags"]) == {"tag1", "tag2", "tag3"}
+        assert set(cfg.nohardlinks["category2"]["exclude_tags"]) == {"tag1", "tag2", "tag4"}
+
+    def test_exclude_tags_empty_per_category_inherits_global(self):
+        """Per-category without exclude_tags should inherit global."""
+        cfg = FakeConfig()
+        cfg.nohardlinks = {
+            "category1": {"exclude_tags": ["tag1", "tag2"], "ignore_root_dir": True},
+        }
+        assert set(cfg.nohardlinks["category1"]["exclude_tags"]) == {"tag1", "tag2"}
+
+    def test_exclude_tags_empty_global_per_category_specified(self):
+        """Per-category exclude_tags without global should work."""
+        cfg = FakeConfig()
+        cfg.nohardlinks = {
+            "category1": {"exclude_tags": ["tag1"], "ignore_root_dir": True},
+        }
+        assert set(cfg.nohardlinks["category1"]["exclude_tags"]) == {"tag1"}
+
+    def test_exclude_tags_both_empty(self):
+        """Both global and per-category empty should result in empty list."""
+        cfg = FakeConfig()
+        cfg.nohardlinks = {
+            "category1": {"exclude_tags": [], "ignore_root_dir": True},
+        }
+        assert cfg.nohardlinks["category1"]["exclude_tags"] == []
+
+    def test_ignore_root_dir_override(self):
+        """Per-category ignore_root_dir should override global_options."""
+        cfg = FakeConfig()
+        cfg.nohardlinks = {
+            "category1": {"exclude_tags": [], "ignore_root_dir": False},
+            "category2": {"exclude_tags": [], "ignore_root_dir": True},
+        }
+        assert cfg.nohardlinks["category1"]["ignore_root_dir"] is False
+        assert cfg.nohardlinks["category2"]["ignore_root_dir"] is True

--- a/tests/test_nohardlinks_global_options.py
+++ b/tests/test_nohardlinks_global_options.py
@@ -199,6 +199,12 @@ class TestGlobalOptionsTypeValidation:
         with pytest.raises(Failed, match="global_options must be a dict"):
             cfg.process_config_nohardlinks()
 
+    @pytest.mark.parametrize("invalid_value", [False, 0, "", []])
+    def test_falsy_global_options_wrong_types_raise_failed(self, invalid_value):
+        cfg = _make_config({"global_options": invalid_value, "cat1": {}})
+        with pytest.raises(Failed, match="global_options must be a dict"):
+            cfg.process_config_nohardlinks()
+
 
 # ---------------------------------------------------------------------------
 # Per-category exclude_tags type validation (pre-existing, kept real)
@@ -279,6 +285,22 @@ class TestGlobalExcludeTagsTypeValidation:
         )
         with pytest.raises(Failed, match="exclude_tags must be a list"):
             cfg.process_config_nohardlinks()
+
+    @pytest.mark.parametrize("invalid_value", [False, 0, ""])
+    def test_falsy_global_exclude_tags_wrong_types_raise_failed(self, invalid_value):
+        cfg = _make_config({"global_options": {"exclude_tags": invalid_value}, "cat1": {}})
+        with pytest.raises(Failed, match="exclude_tags must be a list"):
+            cfg.process_config_nohardlinks()
+
+    def test_duplicate_global_tags_are_deduplicated_in_order(self):
+        cfg = _make_config(
+            {
+                "global_options": {"exclude_tags": ["a", "a"]},
+                "cat1": {"exclude_tags": ["a", "b"]},
+            }
+        )
+        cfg.process_config_nohardlinks()
+        assert cfg.nohardlinks["cat1"]["exclude_tags"] == ["a", "b"]
 
     def test_global_exclude_tags_as_list_is_valid(self):
         """global_options: {exclude_tags: ['tag1']} (list) must not raise."""

--- a/tests/test_nohardlinks_global_options.py
+++ b/tests/test_nohardlinks_global_options.py
@@ -166,6 +166,11 @@ class TestIgnoreRootDirOverride:
 
 
 class TestGlobalOptionsTypeValidation:
+    def test_null_global_options_uses_defaults(self):
+        cfg = _make_config({"global_options": None, "cat1": {}})
+        cfg.process_config_nohardlinks()
+        assert cfg.nohardlinks["cat1"] == {"exclude_tags": [], "ignore_root_dir": True}
+
     def test_global_options_as_string_raises_failed(self):
         """global_options: 'yes please' (string) must raise Failed."""
         cfg = _make_config(
@@ -264,6 +269,11 @@ class TestOuterNohardlinksTypeValidation:
 
 
 class TestGlobalExcludeTagsTypeValidation:
+    def test_null_global_exclude_tags_uses_empty_default(self):
+        cfg = _make_config({"global_options": {"exclude_tags": None}, "cat1": {}})
+        cfg.process_config_nohardlinks()
+        assert cfg.nohardlinks["cat1"]["exclude_tags"] == []
+
     def test_global_exclude_tags_as_string_raises_failed(self):
         """global_options: {exclude_tags: 'tag1'} (string) must raise Failed."""
         cfg = _make_config(

--- a/tests/test_nohardlinks_global_options.py
+++ b/tests/test_nohardlinks_global_options.py
@@ -355,6 +355,18 @@ class TestLegacyListInheritsGlobalOptions:
         cfg.process_config_nohardlinks()
         assert cfg.nohardlinks["tv-series"]["ignore_root_dir"] is False
 
+    @pytest.mark.parametrize("invalid_value", ["false", 0, None])
+    def test_list_of_strings_rejects_invalid_global_ignore_root_dir(self, invalid_value):
+        """List-form categories must not bypass global ignore_root_dir validation."""
+        cfg = _make_config(
+            [
+                {"global_options": {"ignore_root_dir": invalid_value}},
+                "tv-series",
+            ]
+        )
+        with pytest.raises(Failed, match="global_options ignore_root_dir must be a boolean type"):
+            cfg.process_config_nohardlinks()
+
     def test_list_of_strings_no_global_options_uses_defaults(self):
         """Legacy list-of-strings without global_options gets default values."""
         cfg = _make_config(["movies-completed"])

--- a/tests/test_nohardlinks_global_options.py
+++ b/tests/test_nohardlinks_global_options.py
@@ -291,6 +291,28 @@ class TestGlobalExcludeTagsTypeValidation:
         cfg.process_config_nohardlinks()
         assert cfg.nohardlinks["cat1"]["exclude_tags"] == ["tag1"]
 
+    def test_global_exclude_tags_non_string_entry_raises_failed(self):
+        """A non-string global exclude_tags entry must raise Failed, not an unhashable TypeError."""
+        cfg = _make_config(
+            {
+                "global_options": {"exclude_tags": ["ok", ["nested"]]},
+                "cat1": {},
+            }
+        )
+        with pytest.raises(Failed, match="exclude_tags entries must be strings"):
+            cfg.process_config_nohardlinks()
+
+    def test_category_exclude_tags_non_string_entry_raises_failed(self):
+        """A non-string per-category exclude_tags entry must raise Failed, not an unhashable TypeError."""
+        cfg = _make_config(
+            {
+                "global_options": {"exclude_tags": ["g"]},
+                "cat1": {"exclude_tags": ["ok", {"bad": 1}]},
+            }
+        )
+        with pytest.raises(Failed, match="exclude_tags entries must be strings"):
+            cfg.process_config_nohardlinks()
+
 
 # ---------------------------------------------------------------------------
 # Bug 3 — legacy list-form inherits global_options
@@ -312,6 +334,15 @@ class TestLegacyListInheritsGlobalOptions:
         assert cfg.nohardlinks["series-completed"]["exclude_tags"] == ["tracker1.example", "tracker2.example"]
         # global_options itself must NOT become a category key
         assert "global_options" not in cfg.nohardlinks
+
+    def test_list_form_category_literally_named_global_options_is_not_dropped(self):
+        """A bare list-form category literally named 'global_options' must still be
+        processed (only the dict-form global_options key is reserved), preserving
+        backwards-compatibility for legacy list-based configs."""
+        cfg = _make_config(["global_options", "movies-completed"])
+        cfg.process_config_nohardlinks()
+        assert "global_options" in cfg.nohardlinks
+        assert "movies-completed" in cfg.nohardlinks
 
     def test_list_of_strings_inherits_global_ignore_root_dir(self):
         """Legacy list-of-strings entries must inherit global_options ignore_root_dir."""


### PR DESCRIPTION
## Description

Fixes #1072

- Adds optional `global_options` section under `nohardlinks` config for default `exclude_tags` and `ignore_root_dir`
- Per-category `exclude_tags` are **merged** with global (union of both lists)
- Per-category `ignore_root_dir` **overrides** global when explicitly set
- Categories without options inherit global defaults
- Fully backwards compatible: without `global_options`, behavior is identical to before

### Example config
```yaml
nohardlinks:
  global_options:
    exclude_tags:
      - AnimeBytes
    ignore_root_dir: true
  movies-completed-4k:    # inherits: exclude=[AnimeBytes], ignore_root_dir=true
  movies-completed:
    exclude_tags:
      - Beyond-HD          # merged result: [AnimeBytes, Beyond-HD]
    ignore_root_dir: false # overrides global
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have modified this PR to merge to the develop branch
