### PR TITLE
feat: add delay_minutes option for cat_change

### DIFF
--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -78,9 +78,14 @@ cat:
 cat_change:
   # This moves all the torrents from one category to another category. This executes on --cat-update
   # WARNING: if the paths are different and Default Torrent Management Mode is set to automatic the files could be moved !!!
-  # <Old Category Name> : <New Category>
+  # Simple format: <Old Category Name> : <New Category>
   CatA.cross-seed: CatA
-  CatB.cross-seed: CatB
+  # Extended format with delay: wait N minutes after torrent completion before changing category
+  CatB.cross-seed:
+    new_cat: CatB
+    # <OPTIONAL> delay_minutes <int>: Number of minutes after torrent completion to wait before changing the category.
+    # Will default to 0 (no delay) if not specified.
+    delay_minutes: 30
 
 tracker:
   # Mandatory

--- a/docs/Config-Setup.md
+++ b/docs/Config-Setup.md
@@ -185,15 +185,30 @@ This moves all the torrents from one category to another category if the torrent
 > [!CAUTION]
 > If the paths are different and Default Torrent Management Mode is set to Automatic the files could be moved !!!
 
-| Configuration | Definition                    | Required            |
-| :------------ | :---------------------------- | :------------------ |
-| `key`         | Name of the original category | <center>✅</center> |
-| `value`       | Name of the new category      | <center>✅</center> |
+| Configuration | Definition                                                                                                          | Required            |
+| :------------ | :------------------------------------------------------------------------------------------------------------------ | :------------------ |
+| `key`         | Name of the original category                                                                                       | <center>✅</center> |
+| `value`       | Name of the new category (simple format) or an object with `new_cat` and optional `delay_minutes` (extended format) | <center>✅</center> |
 
-The syntax for the categories are as follows
+### Simple format
 
 ```yaml
 old_category_name: new_category_name
+```
+
+### Extended format with delay
+
+You can optionally delay the category change until a specified number of minutes after the torrent has completed downloading. Torrents that have not yet waited long enough will be skipped and picked up on the next run.
+
+| Variable        | Definition                                                                      | Default | Type | Required            |
+| :-------------- | :------------------------------------------------------------------------------ | :------ | :--- | :------------------ |
+| `new_cat`       | Name of the new category                                                        | N/A     | str  | <center>✅</center> |
+| `delay_minutes` | Number of minutes after torrent completion to wait before changing the category | 0       | int  | <center>❌</center> |
+
+```yaml
+old_category_name:
+  new_cat: new_category_name
+  delay_minutes: 30
 ```
 
 ## **tracker:**

--- a/modules/config.py
+++ b/modules/config.py
@@ -352,6 +352,16 @@ class Config:
                     err = f"Config Error: cat_change entry '{old_cat}' has invalid delay_minutes: {delay}"
                     self.notify(err, "Config")
                     raise Failed(err)
+                # Reject floats with non-zero fractional part: int(0.9)=0 would
+                # silently disable the delay; int(30.9)=30 fires ~54s early. PR
+                # #1161 advertises integer minutes — be strict (Copilot review).
+                if isinstance(delay, float) and not delay.is_integer():
+                    err = (
+                        f"Config Error: cat_change entry '{old_cat}' has fractional "
+                        f"delay_minutes={delay}; must be a whole number of minutes."
+                    )
+                    self.notify(err, "Config")
+                    raise Failed(err)
                 result[old_cat] = {"new_cat": str(new_cat), "delay_minutes": int(delay)}
             else:
                 val_type = type(value).__name__

--- a/modules/config.py
+++ b/modules/config.py
@@ -331,6 +331,10 @@ class Config:
         raw = self.data.get("cat_change")
         if not raw:
             return {}
+        if not isinstance(raw, dict):
+            err = f"Config Error: cat_change must be a mapping (dict), got {type(raw).__name__}"
+            self.notify(err, "Config")
+            raise Failed(err)
         result = {}
         for old_cat, value in raw.items():
             if isinstance(value, str):
@@ -348,7 +352,10 @@ class Config:
                     raise Failed(err)
                 result[old_cat] = {"new_cat": str(new_cat), "delay_minutes": int(delay)}
             else:
-                result[old_cat] = {"new_cat": str(value), "delay_minutes": 0}
+                val_type = type(value).__name__
+                err = f"Config Error: cat_change entry '{old_cat}' has invalid type {val_type}; must be string or dict"
+                self.notify(err, "Config")
+                raise Failed(err)
         return result
 
     def process_config_settings(self):

--- a/modules/config.py
+++ b/modules/config.py
@@ -329,12 +329,14 @@ class Config:
         Returns dict mapping old_cat -> {"new_cat": str, "delay_minutes": int}
         """
         raw = self.data.get("cat_change")
-        if not raw:
+        if raw is None:
             return {}
         if not isinstance(raw, dict):
             err = f"Config Error: cat_change must be a mapping (dict), got {type(raw).__name__}"
             self.notify(err, "Config")
             raise Failed(err)
+        if not raw:
+            return {}
         result = {}
         for old_cat, value in raw.items():
             if isinstance(value, str):
@@ -346,7 +348,7 @@ class Config:
                     self.notify(err, "Config")
                     raise Failed(err)
                 delay = value.get("delay_minutes", 0)
-                if not isinstance(delay, (int, float)) or delay < 0:
+                if isinstance(delay, bool) or not isinstance(delay, (int, float)) or delay < 0:
                     err = f"Config Error: cat_change entry '{old_cat}' has invalid delay_minutes: {delay}"
                     self.notify(err, "Config")
                     raise Failed(err)

--- a/modules/config.py
+++ b/modules/config.py
@@ -85,6 +85,49 @@ def validate_share_limit_action(raw, cleanup, group):
     return resolved
 
 
+def normalize_cat_change(raw):
+    """Validate and normalize cat_change config into the canonical mapping
+    ``{old_cat: {"new_cat": str, "delay_minutes": int}}``.
+
+    Accepts the simple form (``old_cat: new_cat``) and the extended form
+    (``old_cat: {new_cat: str, delay_minutes: int}``); raises Failed on invalid
+    input. Pure function — shared by Config._process_cat_change and the test
+    FakeConfig factory so test assertions track production validation rather
+    than a stale local mirror.
+    """
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise Failed(f"Config Error: cat_change must be a mapping (dict), got {type(raw).__name__}")
+    result = {}
+    for old_cat, value in raw.items():
+        if isinstance(value, str):
+            result[old_cat] = {"new_cat": value, "delay_minutes": 0}
+        elif isinstance(value, dict):
+            new_cat = value.get("new_cat")
+            if not new_cat:
+                raise Failed(f"Config Error: cat_change entry '{old_cat}' is missing required 'new_cat' key")
+            if not isinstance(new_cat, str):
+                raise Failed(f"Config Error: cat_change entry '{old_cat}' new_cat must be a string, got {type(new_cat).__name__}")
+            delay = value.get("delay_minutes", 0)
+            if isinstance(delay, bool) or not isinstance(delay, (int, float)) or delay < 0:
+                raise Failed(f"Config Error: cat_change entry '{old_cat}' has invalid delay_minutes: {delay}")
+            # Reject floats with a non-zero fractional part: int(0.9)=0 would silently
+            # disable the delay; int(30.9)=30 fires ~54s early. PR #1161 advertises
+            # integer minutes — be strict (Copilot review).
+            if isinstance(delay, float) and not delay.is_integer():
+                raise Failed(
+                    f"Config Error: cat_change entry '{old_cat}' has fractional "
+                    f"delay_minutes={delay}; must be a whole number of minutes."
+                )
+            result[old_cat] = {"new_cat": new_cat, "delay_minutes": int(delay)}
+        else:
+            raise Failed(
+                f"Config Error: cat_change entry '{old_cat}' has invalid type {type(value).__name__}; must be string or dict"
+            )
+    return result
+
+
 class Config:
     """Config class for qBittorrent-Manage"""
 
@@ -121,10 +164,14 @@ class Config:
         self.data = self.process_config_data()
         self.process_config_settings()
         self.process_config_webhooks()
-        self.cat_change = self._process_cat_change()
         self.process_config_apprise()
         self.process_config_notifiarr()
         self.process_config_all_webhooks()
+        # Must run AFTER process_config_all_webhooks() wraps webhooks_factory into a
+        # Webhooks object: _process_cat_change() calls self.notify() on config errors,
+        # which would raise AttributeError on the still-dict webhooks_factory and mask
+        # the real config error (Copilot review).
+        self.cat_change = self._process_cat_change()
         self.validate_required_sections()
         self.process_config_nohardlinks()
         self.process_config_share_limits()
@@ -328,47 +375,11 @@ class Config:
 
         Returns dict mapping old_cat -> {"new_cat": str, "delay_minutes": int}
         """
-        raw = self.data.get("cat_change")
-        if raw is None:
-            return {}
-        if not isinstance(raw, dict):
-            err = f"Config Error: cat_change must be a mapping (dict), got {type(raw).__name__}"
-            self.notify(err, "Config")
-            raise Failed(err)
-        if not raw:
-            return {}
-        result = {}
-        for old_cat, value in raw.items():
-            if isinstance(value, str):
-                result[old_cat] = {"new_cat": value, "delay_minutes": 0}
-            elif isinstance(value, dict):
-                new_cat = value.get("new_cat")
-                if not new_cat:
-                    err = f"Config Error: cat_change entry '{old_cat}' is missing required 'new_cat' key"
-                    self.notify(err, "Config")
-                    raise Failed(err)
-                delay = value.get("delay_minutes", 0)
-                if isinstance(delay, bool) or not isinstance(delay, (int, float)) or delay < 0:
-                    err = f"Config Error: cat_change entry '{old_cat}' has invalid delay_minutes: {delay}"
-                    self.notify(err, "Config")
-                    raise Failed(err)
-                # Reject floats with non-zero fractional part: int(0.9)=0 would
-                # silently disable the delay; int(30.9)=30 fires ~54s early. PR
-                # #1161 advertises integer minutes — be strict (Copilot review).
-                if isinstance(delay, float) and not delay.is_integer():
-                    err = (
-                        f"Config Error: cat_change entry '{old_cat}' has fractional "
-                        f"delay_minutes={delay}; must be a whole number of minutes."
-                    )
-                    self.notify(err, "Config")
-                    raise Failed(err)
-                result[old_cat] = {"new_cat": str(new_cat), "delay_minutes": int(delay)}
-            else:
-                val_type = type(value).__name__
-                err = f"Config Error: cat_change entry '{old_cat}' has invalid type {val_type}; must be string or dict"
-                self.notify(err, "Config")
-                raise Failed(err)
-        return result
+        try:
+            return normalize_cat_change(self.data.get("cat_change"))
+        except Failed as e:
+            self.notify(str(e), "Config")
+            raise
 
     def process_config_settings(self):
         """

--- a/modules/config.py
+++ b/modules/config.py
@@ -121,7 +121,7 @@ class Config:
         self.data = self.process_config_data()
         self.process_config_settings()
         self.process_config_webhooks()
-        self.cat_change = self.data["cat_change"] if "cat_change" in self.data else {}
+        self.cat_change = self._process_cat_change()
         self.process_config_apprise()
         self.process_config_notifiarr()
         self.process_config_all_webhooks()
@@ -318,6 +318,38 @@ class Config:
             )
             self.notify(err, "Config")
             raise Failed(err)
+
+    def _process_cat_change(self):
+        """
+        Process cat_change config, supporting both simple and extended formats.
+
+        Simple format: old_cat: new_cat
+        Extended format: old_cat: {new_cat: "name", delay_minutes: 30}
+
+        Returns dict mapping old_cat -> {"new_cat": str, "delay_minutes": int}
+        """
+        raw = self.data.get("cat_change")
+        if not raw:
+            return {}
+        result = {}
+        for old_cat, value in raw.items():
+            if isinstance(value, str):
+                result[old_cat] = {"new_cat": value, "delay_minutes": 0}
+            elif isinstance(value, dict):
+                new_cat = value.get("new_cat")
+                if not new_cat:
+                    err = f"Config Error: cat_change entry '{old_cat}' is missing required 'new_cat' key"
+                    self.notify(err, "Config")
+                    raise Failed(err)
+                delay = value.get("delay_minutes", 0)
+                if not isinstance(delay, (int, float)) or delay < 0:
+                    err = f"Config Error: cat_change entry '{old_cat}' has invalid delay_minutes: {delay}"
+                    self.notify(err, "Config")
+                    raise Failed(err)
+                result[old_cat] = {"new_cat": str(new_cat), "delay_minutes": int(delay)}
+            else:
+                result[old_cat] = {"new_cat": str(value), "delay_minutes": 0}
+        return result
 
     def process_config_settings(self):
         """

--- a/modules/core/category.py
+++ b/modules/core/category.py
@@ -69,8 +69,12 @@ class Category:
 
         logger.separator("Changing Categories", space=False, border=False)
         start_time = time.time()
+        now = int(time.time())
 
-        for torrent_category, updated_cat in self.config.cat_change.items():
+        for torrent_category, change_config in self.config.cat_change.items():
+            updated_cat = change_config["new_cat"]
+            delay_minutes = change_config["delay_minutes"]
+
             # Get torrents with the specific category to be changed
             torrent_list_filter = {"status_filter": self.status_filter, "category": torrent_category}
             if self.hashes:
@@ -79,6 +83,19 @@ class Category:
             torrent_list = self.qbt.get_torrents(torrent_list_filter)
 
             for torrent in torrent_list:
+                if delay_minutes > 0:
+                    completion_on = torrent.get("completion_on", 0)
+                    # completion_on is -1 or 0 if not yet completed
+                    if completion_on <= 0:
+                        logger.debug(f"Skipping category change for {torrent.name}: torrent has not completed yet")
+                        continue
+                    elapsed_minutes = (now - completion_on) / 60
+                    if elapsed_minutes < delay_minutes:
+                        logger.debug(
+                            f"Skipping category change for {torrent.name}: "
+                            f"completed {elapsed_minutes:.0f} min ago, delay is {delay_minutes} min"
+                        )
+                        continue
                 self.update_cat(torrent, updated_cat, True)
 
         end_time = time.time()

--- a/modules/core/category.py
+++ b/modules/core/category.py
@@ -89,11 +89,14 @@ class Category:
                     if completion_on <= 0:
                         logger.debug(f"Skipping category change for {torrent.name}: torrent has not completed yet")
                         continue
-                    elapsed_minutes = (now - completion_on) / 60
-                    if elapsed_minutes < delay_minutes:
+                    # Compare in integer seconds (now and completion_on are both int
+                    # epoch seconds) to avoid float rounding at the boundary — fire
+                    # only once a full delay_minutes has elapsed (Copilot review).
+                    elapsed_seconds = now - completion_on
+                    if elapsed_seconds < delay_minutes * 60:
                         logger.debug(
                             f"Skipping category change for {torrent.name}: "
-                            f"completed {elapsed_minutes:.0f} min ago, delay is {delay_minutes} min"
+                            f"completed {elapsed_seconds // 60} min ago, delay is {delay_minutes} min"
                         )
                         continue
                 self.update_cat(torrent, updated_cat, True)

--- a/tests/core/test_category_delay.py
+++ b/tests/core/test_category_delay.py
@@ -1,0 +1,114 @@
+"""Tests for the delay_minutes branch in Category.change_categories().
+
+Uses make_category() bypass so __init__ eager-work doesn't fire.
+All completion_on values are set relative to real time() with deltas
+large enough (>5 s) to be insensitive to clock skew.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from tests.factories import FakeConfig
+from tests.factories import FakeQbtManager
+from tests.factories import FakeTorrent
+from tests.factories import make_category
+
+
+def _now():
+    return int(time.time())
+
+
+def _make_cat(torrents, cat_change):
+    cfg = FakeConfig(cat_change=cat_change)
+    qbt = FakeQbtManager(torrents=torrents, config=cfg)
+    return make_category(qbt)
+
+
+def _set_calls(torrent):
+    return [c for c in torrent.calls if c[0] == "set_category"]
+
+
+# ── delay_minutes=0 fires regardless of completion_on ─────────────────────────
+
+
+def test_delay_zero_fires_immediately():
+    """delay_minutes=0 → category change fires regardless of how recent completion_on is."""
+    t = FakeTorrent(
+        name="Torrent.NAME.1",
+        category="OldCat",
+        # completed just 1 second ago — would be blocked by any positive delay
+        completion_on=_now() - 1,
+    )
+    cat = _make_cat([t], {"OldCat": {"new_cat": "NewCat", "delay_minutes": 0}})
+    cat.change_categories()
+    assert _set_calls(t), "set_category must be called when delay_minutes=0"
+    assert t.category == "NewCat"
+
+
+# ── delay not yet elapsed → skipped ───────────────────────────────────────────
+
+
+def test_delay_not_elapsed_skips_torrent():
+    """delay_minutes=60 + completed 30 min ago → category change must be skipped."""
+    t = FakeTorrent(
+        name="Torrent.NAME.2",
+        category="OldCat",
+        completion_on=_now() - (30 * 60),  # 30 minutes ago
+    )
+    cat = _make_cat([t], {"OldCat": {"new_cat": "NewCat", "delay_minutes": 60}})
+    cat.change_categories()
+    assert _set_calls(t) == [], "set_category must NOT be called when delay has not elapsed"
+    assert t.category == "OldCat"
+
+
+# ── delay elapsed → fires ─────────────────────────────────────────────────────
+
+
+def test_delay_elapsed_fires():
+    """delay_minutes=60 + completed 120 min ago → category change must fire."""
+    t = FakeTorrent(
+        name="Torrent.NAME.3",
+        category="OldCat",
+        completion_on=_now() - (120 * 60),  # 120 minutes ago
+    )
+    cat = _make_cat([t], {"OldCat": {"new_cat": "NewCat", "delay_minutes": 60}})
+    cat.change_categories()
+    assert _set_calls(t), "set_category must be called when delay has elapsed"
+    assert t.category == "NewCat"
+
+
+# ── completion_on sentinel values (not yet completed) → skipped ───────────────
+
+
+@pytest.mark.parametrize("completion_on", [0, -1])
+def test_not_yet_completed_skips(completion_on):
+    """delay_minutes=60 + completion_on in {0, -1} → torrent not yet complete, must skip."""
+    t = FakeTorrent(
+        name="Torrent.NAME.4",
+        category="OldCat",
+        completion_on=completion_on,
+    )
+    cat = _make_cat([t], {"OldCat": {"new_cat": "NewCat", "delay_minutes": 60}})
+    cat.change_categories()
+    assert _set_calls(t) == [], f"set_category must NOT be called when completion_on={completion_on}"
+    assert t.category == "OldCat"
+
+
+# ── boundary: elapsed == delay (inclusive) → fires ────────────────────────────
+
+
+def test_delay_boundary_exactly_elapsed_fires():
+    """delay_minutes=60 + completed exactly 60 min ago → boundary is inclusive, must fire."""
+    # Use 60 min + 2 s buffer to avoid any sub-second race with clock advancing
+    t = FakeTorrent(
+        name="Torrent.NAME.5",
+        category="OldCat",
+        completion_on=_now() - (60 * 60) - 2,
+    )
+    cat = _make_cat([t], {"OldCat": {"new_cat": "NewCat", "delay_minutes": 60}})
+    cat.change_categories()
+    assert _set_calls(t), "set_category must be called at the boundary (elapsed >= delay)"
+    assert t.category == "NewCat"

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -320,6 +320,21 @@ class FakeConfig:
     # webhooks_factory stand-in
     webhooks_factory: Any = field(default_factory=_FakeWebhooksFactory)
 
+    def __post_init__(self):
+        # Mirror modules.config.Config._process_cat_change: tests may pass the
+        # user-facing short form ({old: "new"}); Category consumes the normalized
+        # extended form ({old: {"new_cat": str, "delay_minutes": int}}).
+        normalized = {}
+        for old_cat, value in self.cat_change.items():
+            if isinstance(value, dict):
+                normalized[old_cat] = {
+                    "new_cat": str(value["new_cat"]),
+                    "delay_minutes": int(value.get("delay_minutes", 0)),
+                }
+            else:
+                normalized[old_cat] = {"new_cat": str(value), "delay_minutes": 0}
+        self.cat_change = normalized
+
     def send_notifications(self, attr):
         self.notifications_sent.append(copy.deepcopy(attr))
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -321,19 +321,13 @@ class FakeConfig:
     webhooks_factory: Any = field(default_factory=_FakeWebhooksFactory)
 
     def __post_init__(self):
-        # Mirror modules.config.Config._process_cat_change: tests may pass the
-        # user-facing short form ({old: "new"}); Category consumes the normalized
-        # extended form ({old: {"new_cat": str, "delay_minutes": int}}).
-        normalized = {}
-        for old_cat, value in self.cat_change.items():
-            if isinstance(value, dict):
-                normalized[old_cat] = {
-                    "new_cat": str(value["new_cat"]),
-                    "delay_minutes": int(value.get("delay_minutes", 0)),
-                }
-            else:
-                normalized[old_cat] = {"new_cat": str(value), "delay_minutes": 0}
-        self.cat_change = normalized
+        # Normalize via the production validator (modules.config.normalize_cat_change)
+        # so the test factory and Config stay in lockstep — no stale local mirror that
+        # silently coerces invalid values (e.g. str(True)) or KeyErrors on a missing
+        # new_cat instead of raising the real Config Error.
+        from modules.config import normalize_cat_change
+
+        self.cat_change = normalize_cat_change(self.cat_change)
 
     def send_notifications(self, attr):
         self.notifications_sent.append(copy.deepcopy(attr))

--- a/tests/test_config_cat_change.py
+++ b/tests/test_config_cat_change.py
@@ -39,11 +39,11 @@ def test_cat_change_empty_dict_returns_empty_dict():
     assert result == {}
 
 
-def test_cat_change_empty_list_returns_empty_dict():
-    """cat_change: [] is falsy, treated as missing, returns {}."""
+def test_cat_change_empty_list_raises_failed():
+    """cat_change: [] is a non-dict type and must raise Failed, not silently return {}."""
     config = make_config_with_cat_change([])
-    result = config._process_cat_change()
-    assert result == {}
+    with pytest.raises(Failed, match="cat_change must be a mapping"):
+        config._process_cat_change()
 
 
 def test_cat_change_string_raises_failed():
@@ -121,6 +121,41 @@ def test_cat_change_extended_format_delay_float():
     config = make_config_with_cat_change({"old_cat": {"new_cat": "new_cat", "delay_minutes": 30.5}})
     result = config._process_cat_change()
     assert result == {"old_cat": {"new_cat": "new_cat", "delay_minutes": 30}}
+
+
+def test_cat_change_zero_raises_failed():
+    """cat_change: 0 is falsy but non-dict — must raise Failed, not silently return {}."""
+    config = make_config_with_cat_change(0)
+    with pytest.raises(Failed, match="cat_change must be a mapping"):
+        config._process_cat_change()
+
+
+def test_cat_change_false_raises_failed():
+    """cat_change: False is falsy but non-dict — must raise Failed, not silently return {}."""
+    config = make_config_with_cat_change(False)
+    with pytest.raises(Failed, match="cat_change must be a mapping"):
+        config._process_cat_change()
+
+
+def test_cat_change_empty_string_raises_failed():
+    """cat_change: "" is falsy but non-dict — must raise Failed, not silently return {}."""
+    config = make_config_with_cat_change("")
+    with pytest.raises(Failed, match="cat_change must be a mapping"):
+        config._process_cat_change()
+
+
+def test_cat_change_delay_minutes_true_raises_failed():
+    """delay_minutes: True must raise Failed — bool must not silently coerce to 1."""
+    config = make_config_with_cat_change({"OldCat": {"new_cat": "NewCat", "delay_minutes": True}})
+    with pytest.raises(Failed, match="invalid delay_minutes"):
+        config._process_cat_change()
+
+
+def test_cat_change_delay_minutes_false_raises_failed():
+    """delay_minutes: False must raise Failed — bool must not silently coerce to 0."""
+    config = make_config_with_cat_change({"OldCat": {"new_cat": "NewCat", "delay_minutes": False}})
+    with pytest.raises(Failed, match="invalid delay_minutes"):
+        config._process_cat_change()
 
 
 def test_cat_change_multiple_entries():

--- a/tests/test_config_cat_change.py
+++ b/tests/test_config_cat_change.py
@@ -1,0 +1,138 @@
+"""Tests for cat_change config validation in modules/config.py."""
+
+import pytest
+
+from modules.config import Config
+from modules.util import Failed
+from tests.factories import _FakeWebhooksFactory
+
+
+class _TestConfig(Config):
+    """Minimal Config subclass that overrides notify() to avoid webhook calls."""
+
+    def __init__(self, cat_change_value):
+        self.data = {"cat_change": cat_change_value} if cat_change_value is not None else {}
+        self.webhooks_factory = _FakeWebhooksFactory()
+        self.notify_calls = []
+
+    def notify(self, err, function, *args, **kwargs):
+        """Override notify to avoid trying to call webhooks."""
+        self.notify_calls.append((err, function))
+
+
+def make_config_with_cat_change(cat_change_value):
+    """Create a Config instance with a specific cat_change value for testing."""
+    return _TestConfig(cat_change_value)
+
+
+def test_cat_change_none_returns_empty_dict():
+    """cat_change: None or missing returns {}."""
+    config = make_config_with_cat_change(None)
+    result = config._process_cat_change()
+    assert result == {}
+
+
+def test_cat_change_empty_dict_returns_empty_dict():
+    """cat_change: {} returns {}."""
+    config = make_config_with_cat_change({})
+    result = config._process_cat_change()
+    assert result == {}
+
+
+def test_cat_change_empty_list_returns_empty_dict():
+    """cat_change: [] is falsy, treated as missing, returns {}."""
+    config = make_config_with_cat_change([])
+    result = config._process_cat_change()
+    assert result == {}
+
+
+def test_cat_change_string_raises_failed():
+    """cat_change: "string" raises Failed with type error."""
+    config = make_config_with_cat_change("invalid")
+    with pytest.raises(Failed, match="cat_change must be a mapping"):
+        config._process_cat_change()
+
+
+def test_cat_change_integer_raises_failed():
+    """cat_change: 42 raises Failed with type error."""
+    config = make_config_with_cat_change(42)
+    with pytest.raises(Failed, match="cat_change must be a mapping"):
+        config._process_cat_change()
+
+
+def test_cat_change_value_list_raises_failed():
+    """cat_change entry with list value raises Failed."""
+    config = make_config_with_cat_change({"old_cat": ["invalid", "list"]})
+    with pytest.raises(Failed, match="invalid type"):
+        config._process_cat_change()
+
+
+def test_cat_change_value_integer_raises_failed():
+    """cat_change entry with integer value raises Failed."""
+    config = make_config_with_cat_change({"old_cat": 42})
+    with pytest.raises(Failed, match="invalid type"):
+        config._process_cat_change()
+
+
+def test_cat_change_value_none_raises_failed():
+    """cat_change entry with None value raises Failed."""
+    config = make_config_with_cat_change({"old_cat": None})
+    with pytest.raises(Failed, match="invalid type"):
+        config._process_cat_change()
+
+
+def test_cat_change_simple_format_string():
+    """cat_change: {old: new} normalizes to extended format."""
+    config = make_config_with_cat_change({"old_cat": "new_cat"})
+    result = config._process_cat_change()
+    assert result == {"old_cat": {"new_cat": "new_cat", "delay_minutes": 0}}
+
+
+def test_cat_change_extended_format_with_delay():
+    """cat_change: {old: {new_cat: name, delay_minutes: N}} works correctly."""
+    config = make_config_with_cat_change({"old_cat": {"new_cat": "new_cat", "delay_minutes": 30}})
+    result = config._process_cat_change()
+    assert result == {"old_cat": {"new_cat": "new_cat", "delay_minutes": 30}}
+
+
+def test_cat_change_extended_format_without_delay():
+    """cat_change: {old: {new_cat: name}} defaults delay to 0."""
+    config = make_config_with_cat_change({"old_cat": {"new_cat": "new_cat"}})
+    result = config._process_cat_change()
+    assert result == {"old_cat": {"new_cat": "new_cat", "delay_minutes": 0}}
+
+
+def test_cat_change_extended_format_missing_new_cat():
+    """cat_change entry without new_cat raises Failed."""
+    config = make_config_with_cat_change({"old_cat": {"delay_minutes": 30}})
+    with pytest.raises(Failed, match="missing required 'new_cat' key"):
+        config._process_cat_change()
+
+
+def test_cat_change_extended_format_invalid_delay():
+    """cat_change entry with invalid delay_minutes raises Failed."""
+    config = make_config_with_cat_change({"old_cat": {"new_cat": "new_cat", "delay_minutes": -1}})
+    with pytest.raises(Failed, match="invalid delay_minutes"):
+        config._process_cat_change()
+
+
+def test_cat_change_extended_format_delay_float():
+    """cat_change entry with float delay_minutes is accepted and converted."""
+    config = make_config_with_cat_change({"old_cat": {"new_cat": "new_cat", "delay_minutes": 30.5}})
+    result = config._process_cat_change()
+    assert result == {"old_cat": {"new_cat": "new_cat", "delay_minutes": 30}}
+
+
+def test_cat_change_multiple_entries():
+    """cat_change with multiple entries processes all correctly."""
+    config = make_config_with_cat_change(
+        {
+            "old1": "new1",
+            "old2": {"new_cat": "new2", "delay_minutes": 60},
+        }
+    )
+    result = config._process_cat_change()
+    assert result == {
+        "old1": {"new_cat": "new1", "delay_minutes": 0},
+        "old2": {"new_cat": "new2", "delay_minutes": 60},
+    }

--- a/tests/test_config_cat_change.py
+++ b/tests/test_config_cat_change.py
@@ -116,9 +116,20 @@ def test_cat_change_extended_format_invalid_delay():
         config._process_cat_change()
 
 
-def test_cat_change_extended_format_delay_float():
-    """cat_change entry with float delay_minutes is accepted and converted."""
+def test_cat_change_extended_format_fractional_delay_raises_failed():
+    """Fractional delay_minutes is rejected (added 513b7f9): silent truncation
+    via int() would disable small delays (int(0.9)==0) and fire ~54s early near
+    boundaries (int(30.9)==30). The PR documents integer minutes; enforce it."""
     config = make_config_with_cat_change({"old_cat": {"new_cat": "new_cat", "delay_minutes": 30.5}})
+    with pytest.raises(Failed, match="fractional delay_minutes"):
+        config._process_cat_change()
+
+
+def test_cat_change_extended_format_whole_float_delay_accepted():
+    """A float with no fractional part (e.g. 30.0) is accepted and stored as int 30.
+    YAML can surface integer-valued numbers as floats depending on quoting; the
+    user's intent is unambiguous and there's no truncation drift."""
+    config = make_config_with_cat_change({"old_cat": {"new_cat": "new_cat", "delay_minutes": 30.0}})
     result = config._process_cat_change()
     assert result == {"old_cat": {"new_cat": "new_cat", "delay_minutes": 30}}
 

--- a/web-ui/js/components/config-form.js
+++ b/web-ui/js/components/config-form.js
@@ -1086,6 +1086,28 @@ class ConfigForm {
             return processedData;
         }
 
+        // cat_change uses the complex-object renderer with a {new_cat, delay_minutes}
+        // value. Normalize the legacy simple form (old_cat: "new_cat") and any stale
+        // new_category alias into the canonical object shape so the renderer shows both
+        // fields instead of [object Object] and the save path round-trips delay_minutes.
+        if (sectionName === 'cat_change') {
+            const normalized = {};
+            Object.entries(processedData || {}).forEach(([oldCat, value]) => {
+                if (value && typeof value === 'object' && !Array.isArray(value)) {
+                    normalized[oldCat] = {
+                        new_cat: value.new_cat ?? value.new_category ?? '',
+                        delay_minutes: Number.isFinite(value.delay_minutes) ? value.delay_minutes : 0
+                    };
+                } else {
+                    normalized[oldCat] = {
+                        new_cat: typeof value === 'string' ? value : '',
+                        delay_minutes: 0
+                    };
+                }
+            });
+            return normalized;
+        }
+
         if (sectionConfig && sectionConfig.type === 'fixed-object-config') {
             const mainFieldName = sectionConfig.fields[0]?.name;
             const mainFieldProperties = sectionConfig.fields[0]?.properties || {};

--- a/web-ui/js/config-schemas/cat_change.js
+++ b/web-ui/js/config-schemas/cat_change.js
@@ -22,6 +22,13 @@ export const catChangeSchema = {
                     label: 'New Category Name',
                     description: 'Name of the new category',
                     useCategoryDropdown: true // Flag to indicate this field should use category dropdown
+                },
+                delay_minutes: {
+                    type: 'number',
+                    label: 'Delay Minutes',
+                    description: 'Number of minutes after torrent completion to wait before changing category. Set to 0 for no delay.',
+                    default: 0,
+                    minimum: 0
                 }
             }
         }

--- a/web-ui/js/config-schemas/cat_change.js
+++ b/web-ui/js/config-schemas/cat_change.js
@@ -1,8 +1,9 @@
 export const catChangeSchema = {
     title: 'Category Changes',
     description: 'Move torrents from one category to another after they are marked as complete. Be cautious, as this can cause data to be moved if "Default Torrent Management Mode" is set to automatic in qBittorrent.',
-    type: 'dynamic-key-value-list',
-    useCategoryDropdown: true, // Flag to indicate this should use category dropdown for keys
+    type: 'complex-object',
+    useCategoryDropdown: true, // old-category key uses the category dropdown
+    keyLabel: 'Old Category',
     fields: [
         {
             type: 'documentation',
@@ -10,27 +11,52 @@ export const catChangeSchema = {
             filePath: 'Config-Setup.md',
             section: 'cat_change',
             defaultExpanded: false
-        },
-        {
-            name: 'category_changes',
+        }
+    ],
+    // Value schema: each old category maps to {new_cat, delay_minutes}. These key
+    // names match the backend (modules.config.normalize_cat_change) exactly so the
+    // saved YAML round-trips. The simple form (old_cat: "new_cat") is normalized to
+    // this object shape on load by ConfigForm._preprocessComplexObjectData.
+    patternProperties: {
+        ".*": {
             type: 'object',
-            label: 'Category Changes',
-            description: 'Define old and new category names',
             properties: {
-                new_category: {
-                    type: 'text',
-                    label: 'New Category Name',
-                    description: 'Name of the new category',
-                    useCategoryDropdown: true // Flag to indicate this field should use category dropdown
+                new_cat: {
+                    type: 'string',
+                    label: 'New Category',
+                    description: 'Category to move torrents to once they complete.',
+                    useCategoryDropdown: true
                 },
                 delay_minutes: {
                     type: 'number',
-                    label: 'Delay Minutes',
-                    description: 'Number of minutes after torrent completion to wait before changing category. Set to 0 for no delay.',
+                    label: 'Delay (minutes)',
+                    description: 'Whole minutes after torrent completion to wait before changing category. Set to 0 for no delay.',
                     default: 0,
                     minimum: 0
                 }
-            }
+            },
+            required: ['new_cat'],
+            additionalProperties: false
         }
-    ]
+    },
+    additionalProperties: { // Schema for newly added entries
+        type: 'object',
+        properties: {
+            new_cat: {
+                type: 'string',
+                label: 'New Category',
+                description: 'Category to move torrents to once they complete.',
+                useCategoryDropdown: true
+            },
+            delay_minutes: {
+                type: 'number',
+                label: 'Delay (minutes)',
+                description: 'Whole minutes after torrent completion to wait before changing category. Set to 0 for no delay.',
+                default: 0,
+                minimum: 0
+            }
+        },
+        required: ['new_cat'],
+        additionalProperties: false
+    }
 };

--- a/web-ui/js/config-schemas/cat_change.js
+++ b/web-ui/js/config-schemas/cat_change.js
@@ -32,7 +32,8 @@ export const catChangeSchema = {
                     label: 'Delay (minutes)',
                     description: 'Whole minutes after torrent completion to wait before changing category. Set to 0 for no delay.',
                     default: 0,
-                    minimum: 0
+                    min: 0,
+                    step: 1
                 }
             },
             required: ['new_cat'],
@@ -53,7 +54,8 @@ export const catChangeSchema = {
                 label: 'Delay (minutes)',
                 description: 'Whole minutes after torrent completion to wait before changing category. Set to 0 for no delay.',
                 default: 0,
-                minimum: 0
+                min: 0,
+                step: 1
             }
         },
         required: ['new_cat'],


### PR DESCRIPTION
## Description

Fixes #1074

Adds an optional `delay_minutes` to `cat_change` entries to delay category changes until N minutes after torrent completion. Uses the qBittorrent `completion_on` timestamp.

### Config format

Supports both simple (existing) and extended formats:

```yaml
cat_change:
  # Simple (backwards compatible):
  CatA.cross-seed: CatA

  # Extended with delay:
  CatB.cross-seed:
    new_cat: CatB
    delay_minutes: 30  # Wait 30 min after completion
```

### How it works

1. Config parsing (`_process_cat_change`) normalizes both formats into `{"new_cat": str, "delay_minutes": int}`
2. `change_categories()` checks `torrent.completion_on` timestamp against `delay_minutes` before changing
3. Torrents that haven't waited long enough are skipped (logged at DEBUG level) and will be picked up on the next run

### Changes
- `modules/config.py`: New `_process_cat_change()` method normalizes config format
- `modules/core/category.py`: `change_categories()` checks delay before changing
- `config/config.yml.sample`: Documented extended format with example
- `web-ui/js/config-schemas/cat_change.js`: Added `delay_minutes` field to schema

Fully backwards compatible — simple string format works identically to before.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have modified this PR to merge to the develop branch
