### PR TITLE
fix: pass shareLimitAction to setShareLimits for qBit 5.2.0+ (#1174)

### DIFF
--- a/modules/core/share_limits.py
+++ b/modules/core/share_limits.py
@@ -488,7 +488,12 @@ class ShareLimits:
                     # Clear share limits to prevent qBittorrent from pausing again, then apply throttle
                     if not self.config.dry_run:
                         # Allow continued seeding by removing share limits
-                        torrent.set_share_limits(ratio_limit=-1, seeding_time_limit=-1, inactive_seeding_time_limit=-1)
+                        torrent.set_share_limits(
+                            ratio_limit=-1,
+                            seeding_time_limit=-1,
+                            inactive_seeding_time_limit=-1,
+                            share_limit_action="Default",
+                        )
                         torrent.set_upload_limit(limit_val)
         else:
             self.set_limits(
@@ -653,7 +658,12 @@ class ShareLimits:
                 return []
             if is_tag_in_torrent(self.last_active_tag, torrent.tags):
                 return []
-            torrent.set_share_limits(ratio_limit=max_ratio, seeding_time_limit=max_seeding_time, inactive_seeding_time_limit=-2)
+            torrent.set_share_limits(
+                ratio_limit=max_ratio,
+                seeding_time_limit=max_seeding_time,
+                inactive_seeding_time_limit=-2,
+                share_limit_action="Default",
+            )
         [logger.print_line(msg, self.config.loglevel) for msg in body if do_print]
         return body
 
@@ -697,7 +707,12 @@ class ShareLimits:
                 if not self.config.dry_run:
                     torrent.add_tags(tag)
                     torrent_tags += f", {tag}"
-                    torrent.set_share_limits(ratio_limit=-1, seeding_time_limit=-1, inactive_seeding_time_limit=-1)
+                    torrent.set_share_limits(
+                        ratio_limit=-1,
+                        seeding_time_limit=-1,
+                        inactive_seeding_time_limit=-1,
+                        share_limit_action="Default",
+                    )
                     if reset_upload_speed_on_unmet_minimums:
                         torrent.set_upload_limit(-1)
                     if resume_torrent:


### PR DESCRIPTION
## Summary

Fixes #1174.

qBittorrent WebAPI 2.12.0 (shipped in qBittorrent 5.2.0) made `shareLimitAction` a **required** POST parameter on `torrents/setShareLimits`. qBit Manage's `set_share_limits()` calls didn't pass it, so every share-limits operation against qBit 5.2.0 was failing with:

> `qBittorrent API Error in Share Limits: Missing required parameters: shareLimitAction`

This patch passes `share_limit_action="Default"` at all three `torrent.set_share_limits(...)` call sites in `modules/core/share_limits.py`. `Default` is the qBittorrent enum value that means "use the global default action" (defined as `ShareLimitAction::Default = -1` in `src/base/bittorrent/sharelimits.h`) — so the existing behaviour is preserved on qBit 5.2.0 and unchanged on older versions (the param is simply ignored by versions older than 2.12.0).

### Why hardcode `"Default"`?

The minimal regression fix. A follow-up will expose `share_limit_action` as a per-group config option so users can opt into `Stop` / `Remove` / `RemoveWithContent` / `EnableSuperSeeding` semantics if they want qBit (rather than qbm) to act on the limit.

### Compatibility

- qBit 5.2.0 (WebAPI 2.15.1): fixes the regression — calls now include the required field.
- qBit 5.1.4 and older: backward-compatible — older qBit silently ignores the additional param.
- `qbittorrent-api == 2026.5.1` already supports forwarding `share_limit_action` via `**kwargs` from `TorrentDictionary.set_share_limits` to `torrents_set_share_limits`. No library bump needed.

### References

- qBittorrent WebAPI 2.12.0 changelog: https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2120
- Upstream PR: https://github.com/qbittorrent/qBittorrent/pull/22989
- `ShareLimitAction` enum: https://github.com/qbittorrent/qBittorrent/blob/release-5.2.0/src/base/bittorrent/sharelimits.h

## Out of scope

- Per-group `share_limit_action` config option — separate follow-up.
- Other WebAPI 2.12-2.15 changes (none break qBit Manage today; verified `editTracker`/`use_subcategories`/`auth/login` paths unaffected).