### PR TITLE
chore: ignore mempalace and local agent session files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,11 @@ dist/
 memory-bank
 **/src-tauri/gen
 **/src-tauri/target
+
+# MemPalace per-project memory artifacts
+mempalace.yaml
+entities.json
+
+# Local agent / IDE session artifacts
+.claude-session-name
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Adds gitignore entries for development artifacts that frequently end up in working trees and shouldn't be committed:

- `mempalace.yaml` / `entities.json` — per-project [MemPalace](https://github.com/Pasi-Wallinen/MemPalace) memory artifacts written by the mempalace init script.
- `.claude-session-name` — per-checkout marker file written by some Claude Code session-name hooks.
- `.claude/settings.local.json` — per-developer Claude Code permission overrides (the project may keep `.claude/CLAUDE.md` and `.claude/settings.json` checked in, but `settings.local.json` is per-user).

These are environment artifacts, not project state.