### PR TITLE
chore: tag issue templates with GitHub issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: Please do not use bug reports for support issues.
 title: '[Bug]: '
+type: 'Bug'
 labels: ['bug']
 assignees: 'bobokun'
 

--- a/.github/ISSUE_TEMPLATE/2.feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature Request
 description: Suggest a new feature for Qbit Manage
 title: '[FR]: '
+type: 'Feature'
 labels: ['feature request']
 assignees: 'bobokun'
 

--- a/.github/ISSUE_TEMPLATE/3.docs_request.yml
+++ b/.github/ISSUE_TEMPLATE/3.docs_request.yml
@@ -1,6 +1,7 @@
 name: 'Docs Request for an Update or Improvement'
 description: A request to update or improve Qbit Manage documentation
 title: '[Docs]: '
+type: 'Task'
 labels: ['documentation']
 assignees: 'bobokun'
 


### PR DESCRIPTION
## Summary

Adopts GitHub's native [issue types](https://docs.github.com/en/issues/tracking-your-work-with-issues/configuring-issues/managing-issue-types-in-an-organization) feature on the StuffAnThings org. Issue types are first-class metadata on issues — typed Bug / Feature / Task instead of relying purely on `labels:` strings.

The `StuffAnThings` org has these types defined: **Bug** (red), **Feature** (blue), **Task** (yellow).

### Mapping

| Template | New `type:` field |
|---|---|
| `1.bug_report.yml` | `Bug` |
| `2.feature_request.yml` | `Feature` |
| `3.docs_request.yml` | `Task` |

### Compatibility

The existing `labels:` arrays are kept on every template — anything that filters by label (`bug`, `feature request`, `documentation`) keeps working. The `type:` field is additive metadata.