### PR TITLE
ci: auto-lock stale closed threads + auto-label PRs by paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,46 @@
+# Auto-labels PRs based on changed file paths.
+# Label names must match those in `gh label list` for this repo.
+
+python:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.py"
+          - pyproject.toml
+
+"python:uv":
+  - changed-files:
+      - any-glob-to-any-file:
+          - uv.lock
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "**/*.md"
+          - README.md
+
+github_actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/labeler.yml"
+          - ".github/dependabot.yml"
+          - ".github/ISSUE_TEMPLATE/**"
+          - ".github/pull_request_template.md"
+
+rust:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "desktop/tauri/src-tauri/**/*.rs"
+          - "desktop/tauri/src-tauri/Cargo.toml"
+          - "desktop/tauri/src-tauri/Cargo.lock"
+          - "desktop/tauri/src-tauri/build.rs"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - pyproject.toml
+          - uv.lock
+          - "desktop/tauri/src-tauri/Cargo.toml"
+          - "desktop/tauri/src-tauri/Cargo.lock"
+          - .github/dependabot.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,23 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,43 @@
+name: Lock Closed Threads
+
+on:
+  schedule:
+    # Daily at 06:00 UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v5
+        with:
+          # Lock closed issues / PRs / discussions after 365 days of inactivity.
+          # Avoids necro-comments on long-resolved threads while still leaving
+          # a comfortable window for follow-up questions on a recent merge.
+          issue-inactive-days: '365'
+          pr-inactive-days: '365'
+          discussion-inactive-days: '365'
+          process-only: 'issues, prs, discussions'
+          issue-comment: >
+            This issue has been automatically locked because it has been inactive
+            for 365 days since it was closed. If you are still encountering this
+            problem, please open a new issue.
+          pr-comment: >
+            This pull request has been automatically locked because it has been
+            inactive for 365 days since it was closed.
+          discussion-comment: >
+            This discussion has been automatically locked because it has been
+            inactive for 365 days since it was closed. Please open a new
+            discussion for related follow-ups.
+          # Lock as 'resolved' for issues/discussions; PRs default to no lock-reason.
+          issue-lock-reason: 'resolved'
+          discussion-lock-reason: 'resolved'


### PR DESCRIPTION
## Summary

Two CI hygiene additions wrapped together because they're both passive maintenance you set-and-forget.

### 1. `.github/workflows/lock-threads.yml` — auto-lock closed threads after 365 days

Uses `dessant/lock-threads@v5`. Daily at 06:00 UTC + on-demand `workflow_dispatch`.

Locks closed **issues**, **PRs**, and **discussions** after 365 days of inactivity. Posts a polite comment first explaining why and pointing users to a fresh issue/discussion.

Why 365 days: the year-old window is comfortable for legitimate follow-ups while still preventing necro-comments on threads from multiple years ago.

### 2. `.github/workflows/labeler.yml` + `.github/labeler.yml` — auto-label PRs

Uses `actions/labeler@v5`. Triggers on `pull_request_target` (`opened` / `synchronize` / `reopened`).

Maps changed files to existing repo labels:

| Label | Triggers on |
|---|---|
| `python` | `**/*.py`, `pyproject.toml` |
| `python:uv` | `uv.lock` |
| `documentation` | `docs/**`, `**/*.md`, `README.md` |
| `github_actions` | `.github/workflows/**`, dependabot.yml, ISSUE_TEMPLATE, labeler.yml, pull_request_template.md |
| `rust` | `desktop/tauri/src-tauri/**` |
| `dependencies` | pyproject.toml, uv.lock, Cargo.toml, Cargo.lock, dependabot.yml |

`sync-labels: true` — a label is removed if a follow-up push no longer matches.

### Notes

- Both workflows reuse `secrets.GITHUB_TOKEN` (no PAT needed).
- `pull_request_target` is safe here because `actions/labeler` does not check out PR code — it reads only the changed file list from the PR metadata.
- Type labels are additive; doesn't affect manual labels (e.g., `priority: high`, `bug`).