### PR TITLE
ci: label PRs with merge conflicts

### DIFF
--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -1,0 +1,32 @@
+name: Label Conflicting PRs
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: label-conflicts-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  label-conflicts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PRs with merge conflicts
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: "conflict"
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          commentOnDirty: "This pull request has merge conflicts that must be resolved before it can be merged."
+          commentOnClean: "Conflicts have been resolved. Thanks!"

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-4.7.1-develop2
+4.7.1-develop3


### PR DESCRIPTION
## Summary

- Adds a new workflow `.github/workflows/label-conflicts.yml` that automatically applies the existing `conflict` label to PRs whose base branch (master/develop) has diverged into a merge conflict, and removes the label once the conflict is resolved.
- Triggers on `push` to `master`/`develop` (so PRs get rechecked after a base-branch merge) and on `pull_request_target` open/synchronize/reopen (so PRs get checked when they're created or rebased).
- Uses [`eps1lon/actions-label-merge-conflict@v3`](https://github.com/eps1lon/actions-label-merge-conflict), the most widely used / actively maintained action for this purpose.
- Concurrency-grouped per ref so concurrent triggers don't pile up.

The `conflict` label already exists in the repo (`#5319e7`, "PR is conflicted and needs resolution") — no label changes needed.