### PR TITLE
chore: bump VERSION to 4.7.1-develop3

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-4.7.1-develop2
+4.7.1-develop3


### PR DESCRIPTION
Bump VERSION to ship #1175 (qBit 5.2.0 shareLimitAction fix) to `:develop`. Squash-merge skipped the bump.