### PR TITLE
ci: modernize workflows + dependabot + add release-PR flow + contributor docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,15 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "07:00"
       timezone: "America/Toronto"
     target-branch: "develop"
     assignees:
       - "bobokun"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
     # Reads pyproject.toml and keeps uv.lock in sync on every bump.
     allow:
       - dependency-type: "direct"
@@ -21,11 +24,27 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "07:00"
       timezone: "America/Toronto"
     assignees:
       - "bobokun"
     target-branch: "develop"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
     ignore:
       - dependency-name: "salsify/action-detect-and-tag-new-version"
+  - package-ecosystem: cargo
+    directory: /desktop/tauri/src-tauri
+    schedule:
+      interval: weekly
+      time: "07:00"
+      timezone: "America/Toronto"
+    target-branch: develop
+    assignees:
+      - bobokun
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "rust"

--- a/.github/workflows/bump-version-develop.yml
+++ b/.github/workflows/bump-version-develop.yml
@@ -1,0 +1,63 @@
+name: Bump develop VERSION
+
+# Auto-increments the `-developN` suffix in VERSION on every push to develop
+# (typically a PR merge). Replaces the per-PR-commit pre-commit hook so that
+# contributor PRs no longer carry VERSION bumps and stop hitting rebase
+# conflicts on VERSION.
+#
+# Skips itself: the bump commit is authored as github-actions[bot] with
+# `[skip ci]` in the message, so it does not re-trigger this workflow.
+
+on:
+  push:
+    branches: [develop]
+
+concurrency:
+  group: bump-version-develop
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    # Skip when the head commit is the bot's own bump (defensive — `[skip ci]`
+    # already suppresses workflow re-triggering, but this guards against any
+    # path that might bypass that).
+    if: >-
+      github.actor != 'github-actions[bot]' &&
+      !contains(github.event.head_commit.message, '[skip-version-bump]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v5
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bump develop suffix in VERSION
+        id: bump
+        run: |
+          set -euo pipefail
+          before=$(cat VERSION)
+          output=$(bash scripts/pre-commit/update_develop_version.sh)
+          after=$(cat VERSION)
+          printf 'before=%s\nafter=%s\n' "$before" "$after" >> "$GITHUB_OUTPUT"
+          if [[ "$before" == "$after" ]]; then
+            echo "VERSION unchanged ($before); nothing to commit."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "VERSION bumped: $before -> $after"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push bump
+        if: steps.bump.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add VERSION
+          git commit -m "chore: bump VERSION to ${{ steps.bump.outputs.after }} [skip ci]"
+          git push origin develop

--- a/.github/workflows/bump-version-develop.yml
+++ b/.github/workflows/bump-version-develop.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout develop
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: develop
           fetch-depth: 0

--- a/.github/workflows/dependabot-approve-and-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-auto-merge.yml
@@ -2,6 +2,10 @@ name: Dependabot Pull Request Approve and Merge
 
 on: pull_request
 
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
   issues: write
@@ -11,6 +15,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Checking the actor will prevent your Action run failing on non-Dependabot
     # PRs but also ensures that it only does work for Dependabot PRs.
     if: ${{ github.actor == 'dependabot[bot]' }}
@@ -29,9 +34,10 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Finally, this sets the PR to allow auto-merging for patch and minor
-      # updates if all checks pass
+      # updates if all checks pass. qbittorrent-api is always auto-merged
+      # regardless of semver level (major bumps track qBittorrent releases).
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
+        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' || contains(steps.dependabot-metadata.outputs.dependency-names, 'qbittorrent-api') }}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,9 @@ on:
   gollum:
 
 concurrency:
-  group: docs-sync-${{ github.event_name }}
+  # Single group across push + gollum so the two sync directions don't race.
+  # cancel-in-progress: false — let an in-flight sync finish before the next runs.
+  group: docs-sync
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,10 @@ on:
     types: [docs]
   gollum:
 
+concurrency:
+  group: docs-sync-${{ github.event_name }}
+  cancel-in-progress: false
+
 env:
   GIT_AUTHOR_NAME: Actionbot
   GIT_AUTHOR_EMAIL: actions@github.com
@@ -18,11 +22,15 @@ jobs:
   job-sync-docs-to-wiki:
     runs-on: ubuntu-latest
     if: github.event_name != 'gollum'
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
       - name: Sync docs to wiki
-        uses: newrelic/wiki-sync-action@main
+        # PAT required: wiki and main repo are separate GitHub repositories
+        uses: newrelic/wiki-sync-action@8fb7a9efe4e975bdb2977107fbed96fa0433db52
         with:
           source: docs
           destination: wiki
@@ -33,6 +41,9 @@ jobs:
   job-sync-wiki-to-docs:
     runs-on: ubuntu-latest
     if: github.event_name == 'gollum'
+    timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
@@ -40,7 +51,8 @@ jobs:
           token: ${{ secrets.PAT }} # allows us to push back to repo
           ref: develop
       - name: Sync Wiki to Docs
-        uses: newrelic/wiki-sync-action@main
+        # PAT required: wiki and main repo are separate GitHub repositories
+        uses: newrelic/wiki-sync-action@8fb7a9efe4e975bdb2977107fbed96fa0433db52
         with:
           source: wiki
           destination: docs

--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   label-conflicts:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Label PRs with merge conflicts
         uses: eps1lon/actions-label-merge-conflict@v3

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   label:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/labeler@v6
         with:

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   lock:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: dessant/lock-threads@v6
         with:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   pypi-publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       id-token: write  # Required for trusted publishing to PyPI

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -61,8 +61,16 @@ jobs:
           raw=$(cat VERSION)
           echo "Raw VERSION: $raw"
 
+          # Validate the VERSION file matches the expected X.Y.Z(-developN)? shape
+          # before we strip + arithmetic. Without this, a malformed file (empty
+          # segments, extra text) would silently compute the wrong next version.
+          if ! [[ "$raw" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-develop[0-9]+)?$ ]]; then
+            echo "::error::VERSION file does not match X.Y.Z or X.Y.Z-developN: '$raw'"
+            exit 1
+          fi
+
           # Strip the -developN suffix to get the base version
-          base=$(echo "$raw" | sed 's/-develop[0-9]*//')
+          base="${raw%-develop*}"
           echo "Base version: $base"
 
           IFS='.' read -r MAJOR MINOR PATCH <<< "$base"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -271,13 +271,23 @@ jobs:
 
           printf '%s' "$NOTES" > /tmp/draft_release_notes.md
 
-      - name: Create draft GitHub release
-        uses: softprops/action-gh-release@v2
+      - name: Create draft GitHub release (no tag yet)
+        # Switched from softprops/action-gh-release to ncipollo/release-action
+        # because softprops creates the tag ref immediately on `draft: true`,
+        # which triggers tag-watching workflows (pypi-publish.yml /
+        # version.yml) before the release PR is reviewed + merged.
+        # ncipollo records the tag in the release object but does NOT push
+        # the underlying tag ref while the release stays in draft. The
+        # tag is created post-merge by tag.yml when master advances.
+        # (Copilot review #1200 + operator pick 2026-05-22.)
+        uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-          tag_name: "v${{ needs.prepare-release-branch.outputs.new_version }}"
+          tag: "v${{ needs.prepare-release-branch.outputs.new_version }}"
           name: "v${{ needs.prepare-release-branch.outputs.new_version }}"
-          body_path: /tmp/draft_release_notes.md
+          bodyFile: /tmp/draft_release_notes.md
           draft: true
           prerelease: false
-          target_commitish: ${{ needs.prepare-release-branch.outputs.release_branch }}
+          allowUpdates: true
+          commit: ${{ needs.prepare-release-branch.outputs.release_branch }}
+          skipIfReleaseExists: false

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,275 @@
+name: Release PR
+
+# Creates a release branch (copy of develop), opens a PR to master, and
+# creates a draft GitHub release. Operator reviews the PR, then merges
+# normally — existing tag.yml + pypi-publish.yml + version.yml +
+# update-develop-branch.yml workflows take over from there.
+#
+# IMPORTANT: enable "Automatically delete head branches" in the repo's
+# Settings → General → Pull Requests so the release/vX.Y.Z branch is
+# cleaned up on merge. (Falls back to manual cleanup if not enabled.)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump_type:
+        description: 'Version bump type'
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      release_notes_override:
+        description: 'Override release notes (leave blank to auto-generate from git log)'
+        required: false
+        type: string
+
+concurrency:
+  group: release-pr
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 1: Snapshot develop into release/vX.Y.Z + write bumped VERSION
+  # ─────────────────────────────────────────────────────────────────────────────
+  prepare-release-branch:
+    name: Prepare release branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      new_version: ${{ steps.compute.outputs.new_version }}
+      current_version: ${{ steps.compute.outputs.current_version }}
+      release_branch: ${{ steps.compute.outputs.release_branch }}
+
+    steps:
+      - name: Check Out develop
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Compute new version + release branch name
+        id: compute
+        run: |
+          raw=$(cat VERSION)
+          echo "Raw VERSION: $raw"
+
+          # Strip the -developN suffix to get the base version
+          base=$(echo "$raw" | sed 's/-develop[0-9]*//')
+          echo "Base version: $base"
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$base"
+
+          case "${{ inputs.version_bump_type }}" in
+            major)
+              NEW_VERSION="$((MAJOR + 1)).0.0"
+              ;;
+            minor)
+              NEW_VERSION="${MAJOR}.$((MINOR + 1)).0"
+              ;;
+            patch|*)
+              NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+              ;;
+          esac
+
+          RELEASE_BRANCH="release/v${NEW_VERSION}"
+
+          echo "New version: $NEW_VERSION"
+          echo "Release branch: $RELEASE_BRANCH"
+
+          echo "new_version=$NEW_VERSION"     >> "$GITHUB_OUTPUT"
+          echo "current_version=$raw"          >> "$GITHUB_OUTPUT"
+          echo "release_branch=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+      - name: Create release branch as snapshot of develop
+        run: |
+          BRANCH="${{ steps.compute.outputs.release_branch }}"
+
+          # Refuse to clobber an existing release branch — surfaces stale state early
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "::error::Release branch '$BRANCH' already exists on remote. Delete it first or pick a different version."
+            exit 1
+          fi
+
+          git checkout -b "$BRANCH"
+          echo "Snapshotted develop into $BRANCH at $(git rev-parse HEAD)"
+
+      - name: Write bumped VERSION on release branch
+        run: |
+          echo "${{ steps.compute.outputs.new_version }}" > VERSION
+          echo "VERSION written: $(cat VERSION)"
+
+      - name: Commit + push release branch
+        run: |
+          BRANCH="${{ steps.compute.outputs.release_branch }}"
+          git add VERSION
+          git diff --cached --quiet && echo "No VERSION change to commit" || \
+            git commit -m "chore(release): bump VERSION to ${{ steps.compute.outputs.new_version }} [skip ci]"
+          git push origin "$BRANCH"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 2: Open PR release/vX.Y.Z → master
+  # ─────────────────────────────────────────────────────────────────────────────
+  open-release-pr:
+    name: Open release PR
+    needs: prepare-release-branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check Out release branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare-release-branch.outputs.release_branch }}
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Fetch master for changelog range
+        run: git fetch origin master
+
+      - name: Generate release notes from git log
+        id: notes
+        run: |
+          NEW_VERSION="${{ needs.prepare-release-branch.outputs.new_version }}"
+          OVERRIDE="${{ inputs.release_notes_override }}"
+
+          if [[ -n "$OVERRIDE" ]]; then
+            NOTES="$OVERRIDE"
+          else
+            # Commits on this release branch that are NOT yet on master
+            LOG=$(git log origin/master..HEAD --oneline --no-merges 2>/dev/null || echo "")
+
+            if [[ -z "$LOG" ]]; then
+              NOTES="No new commits since last release."
+            else
+              FEAT=$(echo "$LOG"     | grep -E '^[a-f0-9]+ feat(\(.*\))?:'     || true)
+              FIX=$(echo "$LOG"      | grep -E '^[a-f0-9]+ fix(\(.*\))?:'      || true)
+              REFACTOR=$(echo "$LOG" | grep -E '^[a-f0-9]+ refactor(\(.*\))?:' || true)
+              PERF=$(echo "$LOG"     | grep -E '^[a-f0-9]+ perf(\(.*\))?:'     || true)
+              DOCS=$(echo "$LOG"     | grep -E '^[a-f0-9]+ docs(\(.*\))?:'     || true)
+              TEST=$(echo "$LOG"     | grep -E '^[a-f0-9]+ test(\(.*\))?:'     || true)
+              CI=$(echo "$LOG"       | grep -E '^[a-f0-9]+ ci(\(.*\))?:'       || true)
+              CHORE=$(echo "$LOG"    | grep -E '^[a-f0-9]+ chore(\(.*\))?:'    || true)
+              OTHER=$(echo "$LOG"    | grep -vE '^[a-f0-9]+ (feat|fix|refactor|perf|docs|test|ci|chore)(\(.*\))?:' || true)
+
+              NOTES="## What's Changed in v${NEW_VERSION}"$'\n'$'\n'
+
+              [[ -n "$FEAT" ]]     && NOTES+="### Features"$'\n'"$FEAT"$'\n'$'\n'
+              [[ -n "$FIX" ]]      && NOTES+="### Bug Fixes"$'\n'"$FIX"$'\n'$'\n'
+              [[ -n "$REFACTOR" ]] && NOTES+="### Refactoring"$'\n'"$REFACTOR"$'\n'$'\n'
+              [[ -n "$PERF" ]]     && NOTES+="### Performance"$'\n'"$PERF"$'\n'$'\n'
+              [[ -n "$DOCS" ]]     && NOTES+="### Documentation"$'\n'"$DOCS"$'\n'$'\n'
+              [[ -n "$TEST" ]]     && NOTES+="### Tests"$'\n'"$TEST"$'\n'$'\n'
+              [[ -n "$CI" ]]       && NOTES+="### CI"$'\n'"$CI"$'\n'$'\n'
+              [[ -n "$CHORE" ]]    && NOTES+="### Chores"$'\n'"$CHORE"$'\n'$'\n'
+              [[ -n "$OTHER" ]]    && NOTES+="### Other"$'\n'"$OTHER"$'\n'$'\n'
+            fi
+          fi
+
+          # Footer reminder about branch cleanup
+          NOTES+=$'\n'"---"$'\n'
+          NOTES+="_This PR was opened by the **Release PR** workflow. The \`${{ needs.prepare-release-branch.outputs.release_branch }}\` branch will auto-delete on merge (repo setting \"Automatically delete head branches\")._"$'\n'
+
+          printf '%s' "$NOTES" > /tmp/release_notes.md
+          echo "Notes written."
+
+      - name: Open PR ${{ needs.prepare-release-branch.outputs.release_branch }} → master
+        id: open-pr
+        env:
+          GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ needs.prepare-release-branch.outputs.release_branch }}"
+          NEW_VERSION="${{ needs.prepare-release-branch.outputs.new_version }}"
+
+          PR_URL=$(gh pr create \
+            --base master \
+            --head "$BRANCH" \
+            --title "Release v${NEW_VERSION}" \
+            --body-file /tmp/release_notes.md \
+            --label release)
+
+          echo "Release PR: $PR_URL"
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 3: Create a draft GitHub release (tag not pushed yet)
+  # ─────────────────────────────────────────────────────────────────────────────
+  create-draft-release:
+    name: Create draft GitHub release
+    needs: [prepare-release-branch, open-release-pr]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check Out release branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare-release-branch.outputs.release_branch }}
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Fetch master for changelog range
+        run: git fetch origin master
+
+      - name: Regenerate release notes for GitHub release
+        id: notes
+        run: |
+          NEW_VERSION="${{ needs.prepare-release-branch.outputs.new_version }}"
+          OVERRIDE="${{ inputs.release_notes_override }}"
+
+          if [[ -n "$OVERRIDE" ]]; then
+            NOTES="$OVERRIDE"
+          else
+            LOG=$(git log origin/master..HEAD --oneline --no-merges 2>/dev/null || echo "")
+
+            if [[ -z "$LOG" ]]; then
+              NOTES="No new commits since last release."
+            else
+              FEAT=$(echo "$LOG"     | grep -E '^[a-f0-9]+ feat(\(.*\))?:'     || true)
+              FIX=$(echo "$LOG"      | grep -E '^[a-f0-9]+ fix(\(.*\))?:'      || true)
+              REFACTOR=$(echo "$LOG" | grep -E '^[a-f0-9]+ refactor(\(.*\))?:' || true)
+              PERF=$(echo "$LOG"     | grep -E '^[a-f0-9]+ perf(\(.*\))?:'     || true)
+              DOCS=$(echo "$LOG"     | grep -E '^[a-f0-9]+ docs(\(.*\))?:'     || true)
+              TEST=$(echo "$LOG"     | grep -E '^[a-f0-9]+ test(\(.*\))?:'     || true)
+              CI=$(echo "$LOG"       | grep -E '^[a-f0-9]+ ci(\(.*\))?:'       || true)
+              CHORE=$(echo "$LOG"    | grep -E '^[a-f0-9]+ chore(\(.*\))?:'    || true)
+              OTHER=$(echo "$LOG"    | grep -vE '^[a-f0-9]+ (feat|fix|refactor|perf|docs|test|ci|chore)(\(.*\))?:' || true)
+
+              NOTES="## What's Changed in v${NEW_VERSION}"$'\n'$'\n'
+
+              [[ -n "$FEAT" ]]     && NOTES+="### Features"$'\n'"$FEAT"$'\n'$'\n'
+              [[ -n "$FIX" ]]      && NOTES+="### Bug Fixes"$'\n'"$FIX"$'\n'$'\n'
+              [[ -n "$REFACTOR" ]] && NOTES+="### Refactoring"$'\n'"$REFACTOR"$'\n'$'\n'
+              [[ -n "$PERF" ]]     && NOTES+="### Performance"$'\n'"$PERF"$'\n'$'\n'
+              [[ -n "$DOCS" ]]     && NOTES+="### Documentation"$'\n'"$DOCS"$'\n'$'\n'
+              [[ -n "$TEST" ]]     && NOTES+="### Tests"$'\n'"$TEST"$'\n'$'\n'
+              [[ -n "$CI" ]]       && NOTES+="### CI"$'\n'"$CI"$'\n'$'\n'
+              [[ -n "$CHORE" ]]    && NOTES+="### Chores"$'\n'"$CHORE"$'\n'$'\n'
+              [[ -n "$OTHER" ]]    && NOTES+="### Other"$'\n'"$OTHER"$'\n'$'\n'
+            fi
+          fi
+
+          printf '%s' "$NOTES" > /tmp/draft_release_notes.md
+
+      - name: Create draft GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          tag_name: "v${{ needs.prepare-release-branch.outputs.new_version }}"
+          name: "v${{ needs.prepare-release-branch.outputs.new_version }}"
+          body_path: /tmp/draft_release_notes.md
+          draft: true
+          prerelease: false
+          target_commitish: ${{ needs.prepare-release-branch.outputs.release_branch }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,9 +4,17 @@ on:
   push:
     branches: [ master ]
 
+concurrency:
+  group: tag-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
 jobs:
   tag:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
 
       - uses: actions/checkout@v6

--- a/.github/workflows/update-develop-branch.yml
+++ b/.github/workflows/update-develop-branch.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ master ]
 
+concurrency:
+  group: update-develop
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -11,6 +15,7 @@ jobs:
 
   update-develop:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Check Out Repo

--- a/.github/workflows/update-supported-versions.yml
+++ b/.github/workflows/update-supported-versions.yml
@@ -14,6 +14,10 @@ on:
         required: false
         default: "develop"
 
+concurrency:
+  group: update-supported-versions-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write
@@ -21,6 +25,7 @@ permissions:
 jobs:
   update-versions:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,11 +35,6 @@ repos:
         args: [--fix]
       # Run the formatter.
       - id: ruff-format
-  - repo: local
-    hooks:
-      - id: increase-version
-        name: Increase version if branch contains "develop"
-        entry: ./scripts/pre-commit/increase_version.sh
-        language: script
-        pass_filenames: false
-        stages: [pre-commit]
+      # VERSION bumping moved to .github/workflows/bump-version-develop.yml
+      # (auto-increments on push to develop). PR commits no longer bump
+      # VERSION, so rebases no longer conflict on it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,9 +127,10 @@ the commit in auto-generated release notes.
 
 ## Docs / Wiki
 
-- `docs/` is the source of truth for the [GitHub Wiki](https://github.com/StuffAnThings/qbit_manage/wiki).
-- The `docs.yml` CI workflow auto-syncs `docs/` to the wiki on every push to `develop` — so editing a file in `docs/` *is* how you update the wiki.
-- Do not edit the wiki via the web UI; the next `docs.yml` run will overwrite manual wiki edits.
+- `docs/` and the [GitHub Wiki](https://github.com/StuffAnThings/qbit_manage/wiki) are kept in sync **bidirectionally** by `.github/workflows/docs.yml`:
+  - Push to `develop` touching `docs/**` → CI syncs `docs/` → wiki.
+  - Wiki edit via the GitHub UI → `gollum` event → CI syncs wiki → `docs/` on `develop`.
+- Either side is a valid place to edit; the sync is not instant (each direction is a CI run), but neither side overwrites the other.
 - `docs/Contributing.md` is the contributor guide.
 - `DEVELOPER.md` documents the release flow and CI gates.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+# qBit Manage — Claude Code Project Instructions
+
+**qBit Manage** is a Python automation tool for qBittorrent. It handles
+tagging, share-limit enforcement, category changes, hardlink-aware no-HL
+detection, orphan/unregistered removal, and exposes both a web UI and a REST
+API. Standalone helper scripts live in `scripts/`.
+
+---
+
+## Branch Model
+
+| Branch | Purpose |
+|--------|---------|
+| `develop` | Active development — all PRs target this branch |
+| `master` | Stable releases only — never PR directly to master |
+
+**Always branch from `develop`. Never open a PR to `master`** (except hotfixes
+with `hotfix/` prefix and explicit maintainer approval — see `DEVELOPER.md`).
+
+---
+
+## Dev Environment
+
+```bash
+# Recommended: uv (faster)
+make venv            # creates .venv, installs project + dev deps
+source .venv/bin/activate
+make install-hooks   # installs pre-commit hooks
+
+# Alternative: pip
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+pre-commit install
+```
+
+Key targets:
+
+```bash
+make lint        # ruff check --fix
+make format      # ruff format
+make test        # pytest tests/
+make pre-commit  # run all hooks on all files
+```
+
+---
+
+## Test Commands
+
+```bash
+pytest tests/              # full suite (~168 tests, once PR #1198 merges)
+pytest tests/ --no-cov     # quick run, skip coverage
+pytest tests/test_foo.py   # single file
+```
+
+Tests use `tests/factories.py` bypass-constructors — never instantiate core
+classes directly in tests. Key factories: `make_share_limits()`,
+`make_category()`, `make_tag_nohardlinks()`.
+
+---
+
+## File Layout
+
+```
+qbit_manage.py           # CLI entry point; all argparse definitions here
+modules/
+  config.py              # Config loading; all valid keys defined via check_for_attribute()
+  qbittorrent.py         # qBittorrent API wrapper
+  util.py                # Shared helpers (logging, formatting, file utils)
+  webhooks.py            # Notification webhook support
+  web_api.py             # FastAPI REST server
+  web_ui.py              # Web UI static server
+  core/
+    tags.py              # Torrent tagging logic
+    share_limits.py      # Upload ratio / seeding time enforcement
+    category.py          # Category assignment automation
+    tag_nohardlinks.py   # Hardlink-aware no-HL tagging
+    recheck.py           # Force-recheck stalled torrents
+    remove_orphaned.py   # Remove torrents without matching files
+    remove_unregistered.py  # Remove torrents flagged by tracker as unregistered
+scripts/
+  pre-commit/
+    increase_version.sh        # Auto-bumps developN counter on commit
+    update_develop_version.sh  # Called by increase_version.sh
+tests/
+  factories.py           # Bypass-constructors for unit tests
+docs/                    # Wiki source (synced to GitHub Wiki via docs.yml)
+```
+
+To find which config keys are valid, search `config.py` for
+`check_for_attribute` calls — each call registers a valid key with its type,
+default, and whether it is required.
+
+---
+
+## Conventional Commits
+
+All commits must follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<optional scope>): <description>
+```
+
+Types in use: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `ci`, `perf`.
+
+PR titles must also follow the same format — CI uses the title to categorize
+the commit in auto-generated release notes.
+
+---
+
+## Code Style
+
+- **Ruff** for lint + format; config in `ruff.toml` (line-length=130).
+- Single-line imports (isort rules enforced).
+- Run `make pre-commit` before pushing — CI will reject non-compliant code.
+
+---
+
+## Secrets Hygiene
+
+- `config/config.yml` is gitignored — never commit a real config.
+- The `check_no_tracker_secrets` pre-commit hook (landing with PR #1198)
+  blocks commits that include tracker credentials or announce URLs with
+  embedded tokens.
+- Never bypass with `--no-verify` without maintainer approval.
+
+---
+
+## Docs / Wiki
+
+- `docs/` is the source for the [GitHub Wiki](https://github.com/StuffAnThings/qbit_manage/wiki).
+- The `docs.yml` CI workflow syncs `docs/` to the wiki on every push to `develop`.
+- Edit docs in `docs/` — never edit the wiki directly.
+- `docs/Contributing.md` is the contributor guide.
+- `DEVELOPER.md` documents the release flow and CI gates.
+
+---
+
+## Key References
+
+- **Config keys:** `modules/config.py` — `check_for_attribute()` calls
+- **CLI args:** `qbit_manage.py` — argparse section at the bottom
+- **Release flow:** `DEVELOPER.md`
+- **Contributing guide:** `docs/Contributing.md`
+- **Pre-commit hooks:** `.pre-commit-config.yaml` + `scripts/pre-commit/`
+- **CI workflows:** `.github/workflows/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,9 +127,9 @@ the commit in auto-generated release notes.
 
 ## Docs / Wiki
 
-- `docs/` is the source for the [GitHub Wiki](https://github.com/StuffAnThings/qbit_manage/wiki).
-- The `docs.yml` CI workflow syncs `docs/` to the wiki on every push to `develop`.
-- Edit docs in `docs/` — never edit the wiki directly.
+- `docs/` is the source of truth for the [GitHub Wiki](https://github.com/StuffAnThings/qbit_manage/wiki).
+- The `docs.yml` CI workflow auto-syncs `docs/` to the wiki on every push to `develop` — so editing a file in `docs/` *is* how you update the wiki.
+- Do not edit the wiki via the web UI; the next `docs.yml` run will overwrite manual wiki edits.
 - `docs/Contributing.md` is the contributor guide.
 - `DEVELOPER.md` documents the release flow and CI gates.
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -58,7 +58,7 @@ The operator:
 
 ### Step 3 — Post-Merge Automation (CI, auto-triggered on master push)
 
-Three workflows fire in parallel after the master push:
+Four workflows fire in parallel after the master push:
 
 | Workflow | What it does |
 |----------|-------------|
@@ -106,19 +106,17 @@ Version strings live in a single file: `VERSION` at the repo root.
 
 **Auto-bump mechanics:**
 
-- The `increase-version` pre-commit hook (`scripts/pre-commit/increase_version.sh`)
-  increments the `developN` counter on every local commit when the version
-  contains the word `develop`.
-- In CI (pull request events), the hook checks whether `VERSION` differs from
-  the `develop` branch tip. If the contributor did not bump it manually, the
-  hook runs `update_develop_version.sh` to auto-increment.
+- The `bump-version-develop.yml` CI workflow (`scripts/pre-commit/increase_version.sh`
+  is still present locally for optional manual use) auto-increments the `developN`
+  counter on every push to `develop`. The pre-commit `increase-version` hook has been
+  removed from `.pre-commit-config.yaml`; bumping is now CI-driven.
 - After a master merge, `update-develop-branch.yml` sets the next version:
   it strips the release suffix, bumps the patch segment by 1, and appends
   `-develop1`. Example: `4.7.2` → `4.7.3-develop1`.
 
 **Major/minor bumps** are handled by the Release PR workflow's `version_bump_type`
-input — the workflow computes the new base version before opening the PR, so
-`VERSION` on `develop` is updated before the PR is opened.
+input — the workflow computes the new base version, writes it to the `release/v<NEW>`
+branch, and opens the PR from that branch. `develop` is not modified during this step.
 
 ---
 
@@ -190,7 +188,7 @@ A release with the same version was already uploaded. Increment the version
 (patch bump) and issue a corrective release. PyPI does not allow re-uploading
 the same version.
 
-**Pre-commit hook `increase-version` loops:**
-If the hook keeps bumping `VERSION` on every commit, ensure `VERSION` is not
-already staged before committing. Stage all other changes first, let the hook
-bump `VERSION`, then the hook will detect it is already staged and skip.
+**`bump-version-develop.yml` triggers unexpectedly:**
+This workflow runs on every push to `develop`. If you need to prevent it from
+bumping `VERSION` on a specific push, include `[skip ci]` in the commit message
+or use the `paths-ignore` exemptions already in the workflow.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,196 @@
+# Developer Guide — Release & CI Reference
+
+This document is for maintainers and contributors who need to understand the
+release flow, versioning scheme, CI gates, and secrets hygiene for qBit Manage.
+
+---
+
+## Release Flow
+
+Releases follow a three-step process involving two actors: CI automation and
+the operator (a repository maintainer).
+
+### Step 1 — Open a Release PR (CI, manual trigger)
+
+Trigger the **Release PR** workflow from the GitHub Actions UI:
+
+1. Go to **Actions → Release PR → Run workflow**.
+2. Choose `version_bump_type` (patch / minor / major; default: patch).
+3. Optionally supply `release_notes_override` to replace auto-generated notes.
+
+The workflow:
+- Checks out `develop`, reads `VERSION` (e.g. `4.7.2-develop5`), strips the
+  `-developN` suffix, and computes the new release version per the bump type.
+- **Creates a `release/v<NEW>` branch as a snapshot of develop** (so develop
+  keeps moving while the release stabilizes — the release branch is a frozen
+  copy at the snapshot point).
+- Writes the new version to `VERSION` on the release branch and pushes it.
+- Opens a PR from `release/v<NEW> → master` titled `Release v<NEW>`.
+- PR body is auto-generated from `git log master..release/v<NEW> --oneline`,
+  grouped by Conventional Commit prefix (`feat`, `fix`, `chore`, etc.).
+- Creates a **draft** GitHub release tagged `v<NEW>` (`target_commitish`
+  set to the release branch) with the same notes. The tag is **not pushed**
+  yet — the draft exists only as a preview.
+
+> **Repo setting prerequisite:** enable **Settings → General → Pull Requests
+> → Automatically delete head branches** so the `release/v<NEW>` branch is
+> cleaned up on merge. If it's disabled, you'll need to delete the branch
+> manually after merge.
+
+### Step 2 — Operator Review and Merge
+
+The operator:
+1. Reviews the release PR and checks the draft release notes.
+2. Verifies all CI checks are green on the PR.
+3. Merges `release/v<NEW>` to `master`. **Use `Rebase and merge`** (not
+   squash) so the individual Conventional Commit messages (`feat:`,
+   `fix:`, etc.) survive on master. Rationale:
+   - The project relies on Conventional Commit prefixes for change-log
+     scanning (`git log --grep='^feat:'`) and for the release-notes
+     auto-categorization above. Squashing collapses everything into one
+     "Release v<X.Y.Z>" message and loses that signal.
+   - `update-develop-branch.yml` resets `develop` to `master` after every
+     release, so develop's history ends up matching master's. Rebase keeps
+     that history granular and bisectable.
+   - Individual commits remain revertible.
+
+   The release branch auto-deletes on merge (per the repo setting above).
+
+### Step 3 — Post-Merge Automation (CI, auto-triggered on master push)
+
+Three workflows fire in parallel after the master push:
+
+| Workflow | What it does |
+|----------|-------------|
+| `tag.yml` | Reads `VERSION`, creates and pushes the `v<X.Y.Z>` tag via `Kometa-Team/tag-new-version`. |
+| `pypi-publish.yml` | Triggered by the new `v*` tag; builds the Python package and publishes to PyPI via trusted publishing (OIDC, no API token needed). |
+| `version.yml` | Builds standalone PyInstaller binaries (Linux amd64/arm64, Windows, macOS) and the Tauri desktop bundles; attaches them to the GitHub release. |
+| `update-develop-branch.yml` | Resets `develop` to `master`, bumps `VERSION` to the next patch-develop1 (e.g. `4.7.3-develop1`), force-pushes develop, then triggers `develop.yml` to rebuild Docker develop images. |
+
+The draft release created in Step 1 is promoted to published once `tag.yml`
+pushes the matching tag.
+
+---
+
+## Hot-Fix Flow
+
+For urgent fixes that cannot wait for the normal develop cycle:
+
+1. Create a branch from `master` with the `hotfix/` prefix:
+   ```bash
+   git checkout master
+   git pull origin master
+   git checkout -b hotfix/fix-critical-crash
+   ```
+2. Make the minimal fix. Open a PR directly to `master`.
+3. The PR requires explicit maintainer approval (branch protection rules apply).
+4. Once merged, the same Step 3 automation fires (tag → pypi → version → develop reset).
+5. The hot-fix commit is automatically backported to `develop` by
+   `update-develop-branch.yml` (develop is reset to master after every master push).
+
+> Never cherry-pick hot-fixes to develop manually — the reset workflow handles
+> it, and manual cherry-picks create divergence.
+
+---
+
+## Versioning
+
+Version strings live in a single file: `VERSION` at the repo root.
+
+**Format:**
+
+| Branch | Example | Meaning |
+|--------|---------|---------|
+| `develop` (active dev) | `4.7.2-develop5` | 5th auto-bump since 4.7.2 was cut |
+| `master` (release) | `4.7.2` | Released version |
+
+**Auto-bump mechanics:**
+
+- The `increase-version` pre-commit hook (`scripts/pre-commit/increase_version.sh`)
+  increments the `developN` counter on every local commit when the version
+  contains the word `develop`.
+- In CI (pull request events), the hook checks whether `VERSION` differs from
+  the `develop` branch tip. If the contributor did not bump it manually, the
+  hook runs `update_develop_version.sh` to auto-increment.
+- After a master merge, `update-develop-branch.yml` sets the next version:
+  it strips the release suffix, bumps the patch segment by 1, and appends
+  `-develop1`. Example: `4.7.2` → `4.7.3-develop1`.
+
+**Major/minor bumps** are handled by the Release PR workflow's `version_bump_type`
+input — the workflow computes the new base version before opening the PR, so
+`VERSION` on `develop` is updated before the PR is opened.
+
+---
+
+## CI Gates
+
+Every PR to `develop` runs the `develop.yml` workflow, which includes:
+
+- **Ruff** — lint and format check (non-zero exit blocks merge)
+- **yamllint** — strict YAML validation for any changed YAML files
+- **pytest** — full test suite (once PR #1198 lands, `~168` tests)
+- **Docker build** — multi-arch image build (amd64, arm64, arm/v7) to catch
+  import and dependency errors before release
+
+The Release PR to `master` must also pass these same checks. Branch protection
+on `master` requires at least one maintainer approval and all status checks
+green.
+
+---
+
+## Secrets Hygiene
+
+### check_no_tracker_secrets (pre-commit)
+
+Once PR #1198 merges, a local pre-commit hook (`check_no_tracker_secrets.py`)
+will scan staged files for patterns that match tracker credentials (API keys,
+passkeys, announce URLs with embedded tokens). The hook blocks commits that
+would accidentally include live tracker credentials sourced from a local
+`config/config.yml`.
+
+**If the hook fires:**
+1. Remove or redact the credential from the staged file.
+2. Add the file to `.gitignore` if it should never be committed (e.g. a
+   personal config snippet).
+3. If this is a false positive, contact a maintainer — do not bypass with
+   `--no-verify` without explicit approval.
+
+### Workflow secrets
+
+| Secret | Used by | Purpose |
+|--------|---------|---------|
+| `PAT` | `tag.yml`, `update-develop-branch.yml` | Push tags and force-push develop (bypasses branch protection) |
+| `GITHUB_TOKEN` | Most workflows | Default Actions token for read operations and PR creation |
+| PyPI OIDC | `pypi-publish.yml` | Trusted publishing — no stored API token |
+
+Secrets are managed in the repository's **Settings → Secrets and variables →
+Actions**. Never hardcode tokens in workflow files.
+
+---
+
+## Troubleshooting
+
+**Release PR workflow fails on version parse:**
+The workflow expects `VERSION` to match `X.Y.Z-developN` on the `develop`
+branch. If `VERSION` was manually edited to an unexpected format, correct it
+before re-triggering.
+
+**`update-develop-branch.yml` fails to force-push develop:**
+This workflow requires the `PAT` secret (a personal access token with `repo`
+scope and admin bypass for branch protection). Verify the secret is set and
+has not expired.
+
+**tag.yml creates the wrong tag:**
+`Kometa-Team/tag-new-version` reads `VERSION` verbatim. If the version on
+`master` contains a `-develop` suffix (it should not after a proper release
+merge), the tag will be wrong. Fix `VERSION` on master and re-run the workflow.
+
+**PyPI publish fails with 400 Conflict:**
+A release with the same version was already uploaded. Increment the version
+(patch bump) and issue a corrective release. PyPI does not allow re-uploading
+the same version.
+
+**Pre-commit hook `increase-version` loops:**
+If the hook keeps bumping `VERSION` on every commit, ensure `VERSION` is not
+already staged before committing. Stage all other changes first, let the hook
+bump `VERSION`, then the hook will detect it is already staged and skip.

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -93,7 +93,6 @@ Hooks run automatically on `git commit`. They enforce:
 | `yamllint` + `yamlfix` | Strict YAML style lint and auto-fix |
 | `ruff-check` | Lints Python with auto-fix |
 | `ruff-format` | Formats Python |
-| `increase-version` | Bumps the `developN` counter in `VERSION` on develop branches |
 | `check_no_tracker_secrets` | (Once PR #1198 merges) Prevents accidental commit of tracker credentials from config files |
 
 Run all hooks manually at any time:

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -1,33 +1,54 @@
-# Contributing & Building
+# Contributing to qBit Manage
 
-Pull requests are welcome! Please submit them to the [develop branch](https://github.com/StuffAnThings/qbit_manage/tree/develop).
+Pull requests are welcome! Please target the **`develop`** branch — PRs to `master` will not be accepted.
 
-## Prerequisites
+---
 
-- **Python 3.10+**
-- **Git**
-- **[uv](https://docs.astral.sh/uv/)** (Python package manager)
-- **[Rust](https://rustup.rs/)** (only for desktop app builds)
+## Quick Start
 
-## Development Setup
+### 1. Fork and Clone
 
 ```bash
-# Clone the repository
-git clone https://github.com/StuffAnThings/qbit_manage.git
+# Fork via GitHub, then:
+git clone https://github.com/<your-username>/qbit_manage.git
 cd qbit_manage
 git checkout develop
-
-# Create virtual environment and install all dependencies (including dev tools)
-make venv
-
-# Activate the virtual environment
-source .venv/bin/activate
-
-# Install pre-commit hooks
-make install-hooks
 ```
 
-The `make venv` target handles everything: installs uv if needed, creates a `.venv`, installs the project in editable mode, and adds dev dependencies (pre-commit, ruff).
+### 2. Create a Branch
+
+Branch from `develop`. Use a descriptive name:
+
+```bash
+git checkout -b fix/share-limits-edge-case
+git checkout -b feat/new-tagging-option
+```
+
+### 3. Set Up Your Dev Environment
+
+**Option A — uv (recommended, faster):**
+
+```bash
+# Install uv if not already present
+curl -Lsf https://astral.sh/uv/install.sh | sh
+
+make venv            # creates .venv, installs project + dev deps
+source .venv/bin/activate
+make install-hooks   # install pre-commit hooks
+```
+
+**Option B — pip + venv:**
+
+```bash
+python -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+pip install -e ".[dev]"
+pre-commit install
+```
+
+> uv is also kept current via Dependabot (uv ecosystem), so lock-file updates happen automatically.
+
+---
 
 ## Common Make Targets
 
@@ -35,147 +56,168 @@ The `make venv` target handles everything: installs uv if needed, creates a `.ve
 |--------|-------------|
 | `make venv` | Create virtual environment and install all dependencies |
 | `make install-hooks` | Install pre-commit hooks into your local repo |
-| `make test` | Run the test suite |
+| `make test` | Run the full test suite |
 | `make lint` | Run ruff linter with auto-fix |
 | `make format` | Run ruff code formatter |
 | `make pre-commit` | Run all pre-commit hooks on all files |
-| `make build` | Build Python package for distribution |
-| `make install` | Install qbit-manage as a `uv tool` (system-wide CLI) |
-| `make clean` | Remove all generated files (venv, dist, build, cache) |
-| `make help` | Show all available targets (including release/publishing targets) |
+| `make clean` | Remove generated files (venv, dist, build, cache) |
+| `make help` | List all available targets |
+
+---
 
 ## Code Style
 
-The project uses [Ruff](https://docs.astral.sh/ruff/) for both linting and formatting:
+The project uses [Ruff](https://docs.astral.sh/ruff/) for linting and formatting:
 
-- **Line length**: 130 characters
-- **Import style**: Single-line imports (enforced by isort rules)
-- **Pre-commit hooks** run automatically on commit and enforce:
-  - Trailing whitespace removal
-  - End-of-file fixer
-  - JSON/YAML validation
-  - Ruff linting and formatting
-  - Automatic develop version bumping
+- **Line length:** 130 characters (see `ruff.toml`)
+- **Import style:** Single-line imports (isort rules enforced)
 
-## Building
-
-### Standalone Binary (PyInstaller)
-
-The standalone binary bundles Python, all dependencies, the web UI, and docs into a single executable.
+Run before committing:
 
 ```bash
-# Activate the virtual environment
-source .venv/bin/activate
-
-# Install PyInstaller
-pip install pyinstaller
-
-# Build the binary
-pyinstaller --noconfirm --clean --onefile \
-    --name qbit-manage \
-    --add-data "web-ui:web-ui" \
-    --add-data "config/config.yml.sample:config" \
-    --add-data "icons/qbm_logo.png:." \
-    --add-data "VERSION:." \
-    --add-data "docs:docs" \
-    qbit_manage.py
-
-# Binary will be in dist/qbit-manage
-./dist/qbit-manage --help
+ruff check --fix .
+ruff format .
 ```
 
-> **Note:** PyInstaller produces a binary for the architecture of the machine you build on. To get an ARM64 binary, build on an ARM64 machine.
+---
 
-> **Note:** On Windows, replace `:` with `;` in the `--add-data` arguments (e.g., `--add-data "web-ui;web-ui"`).
+## Pre-Commit Hooks
 
-### Desktop App (Tauri)
+Hooks run automatically on `git commit`. They enforce:
 
-The desktop app wraps the standalone binary in a [Tauri v2](https://v2.tauri.app/) shell with a native window, system tray, and the web UI as the frontend.
+| Hook | What it does |
+|------|-------------|
+| `trailing-whitespace` | Strips trailing spaces |
+| `end-of-file-fixer` | Ensures files end with a newline |
+| `check-json` / `check-yaml` | Validates JSON and YAML syntax |
+| `yamllint` + `yamlfix` | Strict YAML style lint and auto-fix |
+| `ruff-check` | Lints Python with auto-fix |
+| `ruff-format` | Formats Python |
+| `increase-version` | Bumps the `developN` counter in `VERSION` on develop branches |
+| `check_no_tracker_secrets` | (Once PR #1198 merges) Prevents accidental commit of tracker credentials from config files |
 
-#### Install Tauri Build Dependencies
-
-**Linux (Debian/Ubuntu):**
-```bash
-sudo make tauri-deps
-```
-
-This installs the required system packages (`build-essential`, `libgtk-3-dev`, `libwebkit2gtk-4.1-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`, `patchelf`, and more). Requires root for `apt-get`.
-
-**macOS:** Xcode Command Line Tools are sufficient.
-
-**Windows:** Install [NSIS](https://nsis.sourceforge.io/) (e.g., `choco install nsis`).
-
-#### Build Steps
-
-1. **Build the standalone binary first** (see above) and copy it into the Tauri sidecar directory with the platform-specific name:
-   ```bash
-   mkdir -p desktop/tauri/src-tauri/bin
-
-   # Copy only YOUR platform's binary (pick one):
-   cp dist/qbit-manage desktop/tauri/src-tauri/bin/qbit-manage-linux-amd64   # x86_64 Linux
-   # cp dist/qbit-manage desktop/tauri/src-tauri/bin/qbit-manage-linux-arm64   # ARM64 Linux
-   # cp dist/qbit-manage desktop/tauri/src-tauri/bin/qbit-manage-macos-arm64   # Apple Silicon
-   # cp dist/qbit-manage desktop/tauri/src-tauri/bin/qbit-manage-macos-x86_64  # Intel Mac
-
-   chmod +x desktop/tauri/src-tauri/bin/qbit-manage-*
-   ```
-
-2. **Install the Tauri CLI and build:**
-   ```bash
-   cd desktop/tauri/src-tauri
-   cargo install tauri-cli --version ^2 --locked
-   cargo tauri build --bundles deb   # Linux: produces .deb in target/release/bundle/deb/
-   cargo tauri build --bundles dmg   # macOS: produces .dmg
-   cargo tauri build --bundles nsis  # Windows: produces installer .exe
-   ```
-
-The build script (`build.rs`) automatically reads the `VERSION` file and updates `Cargo.toml` and `tauri.conf.json` to keep versions in sync.
-
-### Docker Image
+Run all hooks manually at any time:
 
 ```bash
-docker build -t qbit-manage .
+make pre-commit
+# or directly:
+pre-commit run --all-files
 ```
 
-The Dockerfile is a multi-stage Alpine build. For multi-architecture builds (amd64, arm64, arm/v7), the CI uses Docker Buildx with QEMU.
+---
+
+## Tests
+
+> Tests land with PR #1198. Until that PR merges, the test suite is not present on `develop`.
+
+Once available:
+
+```bash
+pytest tests/              # full suite (~168 tests)
+pytest tests/ --no-cov     # quick run, skip coverage report
+```
+
+**Test scaffolding pattern** (`tests/factories.py`):
+
+The factories module provides bypass-constructors that create objects without
+needing a live qBittorrent connection. Key helpers:
+
+- `make_share_limits()` — returns a configured `ShareLimits` instance
+- `make_category()` — returns a `Category` instance
+- `make_tag_nohardlinks()` — returns a `TagNoHardLinks` instance
+
+Use these in your own test fixtures rather than instantiating core classes
+directly. Each factory accepts keyword arguments to override defaults, keeping
+tests readable and isolated.
+
+---
+
+## Commit Messages
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <short description>
+```
+
+Scopes are optional but encouraged (e.g., `share_limits`, `tags`, `config`).
+
+**Types used in this repo** (verified against git history):
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New feature or behavior |
+| `fix` | Bug fix |
+| `refactor` | Code restructuring, no behavior change |
+| `chore` | Dependency bumps, tooling, housekeeping |
+| `docs` | Documentation only |
+| `test` | Adding or updating tests |
+| `ci` | CI/CD workflow changes |
+| `perf` | Performance improvements |
+
+Examples from the log:
+```
+feat(tags): add support for tagging private torrents
+fix(share_limits): set limits when throttle skipped
+refactor(share_limits): simplify logic and reduce code duplication
+chore(deps): bump ruff from 0.14.5 to 0.14.6
+```
+
+---
+
+## Submitting a PR
+
+1. Ensure `make pre-commit` passes with no errors.
+2. Run `pytest tests/` (once available) and confirm no regressions.
+3. Push your branch and open a PR against **`develop`** — not `master`.
+4. Describe what your PR does and link any related issues.
+5. A maintainer will review; CI must be green before merge.
+
+For the release process (merging `develop → master`, tagging, PyPI publish),
+see [`DEVELOPER.md`](../DEVELOPER.md).
+
+---
 
 ## Project Structure
 
 ```
 qbit_manage/
-├── qbit_manage.py          # Main entry point
-├── modules/                # Core application modules
-├── web-ui/                 # Web UI frontend (HTML/CSS/JS)
-│   ├── index.html
-│   ├── js/
-│   └── css/
-├── desktop/tauri/          # Tauri desktop app shell
-│   └── src-tauri/
-│       ├── src/            # Rust source
-│       ├── bin/            # Sidecar binaries (gitignored, populated at build time)
-│       ├── Cargo.toml
-│       ├── build.rs        # Version sync script
-│       └── tauri.conf.json # Tauri configuration
-├── config/                 # Sample configuration files
-├── docs/                   # Wiki documentation (synced to GitHub wiki)
-├── icons/                  # Application icons
+├── qbit_manage.py          # Main entry point and CLI argument parsing
+├── modules/                # Core application logic
+│   ├── config.py           # Config loading; check_for_attribute() calls define all valid keys
+│   ├── qbittorrent.py      # qBittorrent API wrapper
+│   ├── util.py             # Shared helpers and utilities
+│   ├── webhooks.py         # Webhook notification support
+│   ├── web_api.py          # REST API server
+│   ├── web_ui.py           # Web UI server
+│   └── core/               # Per-feature modules
+│       ├── tags.py
+│       ├── share_limits.py
+│       ├── category.py
+│       ├── tag_nohardlinks.py
+│       ├── recheck.py
+│       ├── remove_orphaned.py
+│       └── remove_unregistered.py
+├── tests/                  # Test suite (landing with PR #1198)
+│   └── factories.py        # Bypass-constructors for unit testing
 ├── scripts/                # Standalone helper scripts
+│   └── pre-commit/         # Pre-commit hook scripts
+├── web-ui/                 # Web UI frontend (HTML/CSS/JS)
+├── desktop/tauri/          # Tauri desktop app shell
+├── docs/                   # Wiki documentation (synced to GitHub Wiki)
+├── config/                 # Sample configuration files
+├── icons/                  # Application icons
 ├── Makefile                # Development automation
 ├── Dockerfile              # Docker build
 ├── pyproject.toml          # Python project configuration
+├── ruff.toml               # Ruff linter/formatter config
 └── VERSION                 # Single source of truth for version
 ```
 
-## Submitting Changes
-
-1. Fork the repository and create a branch from `develop`
-2. Make your changes and ensure `make pre-commit` passes
-3. Test your changes locally
-4. Submit a pull request to the `develop` branch
-5. Describe what your PR does and why
+---
 
 ## Support
 
-- **Questions**: Join the [Notifiarr Discord](https://discord.com/invite/AURf8Yz) and post in the `qbit-manage` channel
-- **Bugs/Enhancements**: Open an [Issue](https://github.com/StuffAnThings/qbit_manage/issues/new)
-- **Config Questions**: Start a [Discussion](https://github.com/StuffAnThings/qbit_manage/discussions/new)
+- **Questions:** Join the [Notifiarr Discord](https://discord.com/invite/AURf8Yz) → `#qbit-manage` channel
+- **Bugs / Enhancements:** Open an [Issue](https://github.com/StuffAnThings/qbit_manage/issues/new)
+- **Config Questions:** Start a [Discussion](https://github.com/StuffAnThings/qbit_manage/discussions/new)


### PR DESCRIPTION
## Summary

End-to-end audit + hardening of the GitHub Actions surface, plus contributor-facing docs.

## Changes

### Workflow hardening (10 existing files)
- **Concurrency groups** added to `docs.yml`, `tag.yml`, `update-develop-branch.yml`, `update-supported-versions.yml`, `dependabot-approve-and-auto-merge.yml`. `cancel-in-progress: false` for release-critical paths (tags, wiki-sync, develop-reset); `cancel-in-progress: true` elsewhere.
- **Explicit `permissions:` blocks** (least-privilege) where missing.
- **`timeout-minutes`** added to every job (5–15 min depending on workload) to bound runaway runs.
- **`newrelic/wiki-sync-action@main`** pinned to commit `8fb7a9ef…` (the v1.0.1 tag is behind main, so pinning HEAD-of-main is the correct supply-chain hygiene).
- **`dependabot-approve-and-auto-merge.yml`**: allow `qbittorrent-api` dependabot PRs to auto-merge on semver-major. Reason: qbit_manage couples tightly to the upstream qbittorrent-api release cadence.

### `dependabot.yml`
- New **`cargo`** ecosystem for `desktop/tauri/src-tauri` (Rust/Tauri deps were unmonitored).
- **uv** + **github-actions** intervals: `daily` → `weekly` (noise reduction; security advisories still come in real-time).
- **`open-pull-requests-limit`** added (10 for uv, 5 for github-actions and cargo).
- **`labels:`** per ecosystem so PR Labeler results stay consistent.

### New release-PR workflow — `.github/workflows/release-pr.yml`
- `workflow_dispatch` only. Inputs: `version_bump_type` (patch/minor/major) + optional `release_notes_override`.
- Strips `-developN` suffix from `VERSION`, computes next semver, writes new VERSION on develop.
- Opens `develop → master` PR with auto-generated notes (`git log master..develop --oneline`) categorized by Conventional Commit prefix.
- Creates a **draft** GitHub release with tag `v<NEW>` (tag pushed for real by existing `tag.yml` once master receives the merge).
- See `DEVELOPER.md` for the full flow.

### Contributor docs
- **`docs/Contributing.md`** rewritten — fork/clone, dev install, pre-commit hooks, test layout (forward-references PR #1198's `tests/` scaffold), conventional commits, target `develop`, secrets hygiene.
- **`DEVELOPER.md`** (new) — release flow, hotfix flow, versioning, CI gates, secrets hygiene, troubleshooting.
- **`CLAUDE.md`** (new, repo root) — project-level Claude Code instructions.

## Follow-ups out of scope (tracked separately)
- Pin `Kometa-Team/tag-new-version@master` (in `tag.yml`) to a commit SHA.
- Pin `pypa/gh-action-pypi-publish@release/v1` (in `pypi-publish.yml`) to a commit SHA.

## Cross-PR ordering
- This PR is **independent** of #1198 (pytest framework) and #1199 (redact_passkey). It only touches the 11 workflows that already exist on develop.
- The `release-pr.yml` workflow does not depend on any of the other open PRs; it can land anytime.

## Test plan
- [x] All modified workflow YAMLs parse via `python3 -c "import yaml; yaml.safe_load(open(<f>))"`
- [ ] PR Labeler / Label Conflicting / Dependabot Approve / secrets-scan (post-merge from #1198) all green
- [ ] Manual smoke test of `release-pr.yml` once merged: trigger on develop, verify draft release + PR creation