### PR TITLE
ci: pin floating GHA action refs (follow-up to #1200)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -46,7 +46,8 @@ jobs:
 
       - name: Publish to Test PyPI
         if: ${{ github.event.inputs.test_pypi == 'true' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # Pinned per supply-chain hygiene; bump SHA on next dependabot review
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           repository-url: https://test.pypi.org/legacy/
           # Option 1: Use trusted publishing (recommended)
@@ -58,7 +59,8 @@ jobs:
 
       - name: Publish to PyPI
         if: ${{ github.event.inputs.test_pypi != 'true' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # Pinned per supply-chain hygiene; bump SHA on next dependabot review
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           # Option 1: Use trusted publishing (recommended)
           # Repository must be configured in PyPI with GitHub as trusted publisher

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,7 +14,8 @@ jobs:
           token: ${{ secrets.PAT }}
           fetch-depth: 2
 
-      - uses: Kometa-Team/tag-new-version@master
+      # Pinned per supply-chain hygiene; bump SHA on next dependabot review
+      - uses: Kometa-Team/tag-new-version@1dd1fb186f3f5229331e8ddf6515288633a2412e
         with:
           version-command: |
             cat VERSION

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-4.7.2-develop2
+4.7.2-develop3


### PR DESCRIPTION
Follow-up to #1200 (ci/modernization). Pins the two remaining floating refs:

- `Kometa-Team/tag-new-version@master` → `1dd1fb186f3f5229331e8ddf6515288633a2412e`
- `pypa/gh-action-pypi-publish@release/v1` → `cef221092ed1bacb1cc03d23a2d87d1d172e277b`

Both upstream are reputable, but pinning to a SHA gives us deterministic builds and a clear bump point when dependabot proposes an update. Comments added above each `uses:` line note the policy.