### PR TITLE
chore: bump runtime Python guard to >=3.10 (match pyproject.toml)

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-4.7.2-develop2
+4.7.2-develop3

--- a/qbit_manage.py
+++ b/qbit_manage.py
@@ -35,7 +35,7 @@ except ModuleNotFoundError:
     print("Requirements Error: Requirements are not installed")
     sys.exit(1)
 
-REQUIRED_VERSION = (3, 8, 1)
+REQUIRED_VERSION = (3, 10)
 REQUIRED_VERSION_STR = ".".join(str(x) for x in REQUIRED_VERSION)
 current_version = sys.version_info
 


### PR DESCRIPTION
The runtime version guard at `qbit_manage.py:38` checked `(3, 8, 1)` — a leftover from when the project supported Python 3.8. `pyproject.toml` already requires `>=3.10` (so pip/uv installs are gated correctly), but the runtime check was stale and confusing.

This aligns the runtime guard with the package metadata.

Follow-up to wiki doc-audit pass 2026-05-22 (one of the items flagged was the Installation.md "Python 3.9 minimum" claim, which was already fixed in the wiki; this PR closes the loop on the in-repo runtime check).

No other compose-file `version:` keys were found in the repo (parallel cleanup item #9 audit).