### PR TITLE
refactor(logging): improve nohardlinks and share-limits debug/trace logging

### DIFF
--- a/modules/core/share_limits.py
+++ b/modules/core/share_limits.py
@@ -538,15 +538,19 @@ class ShareLimits:
         tags_set = set(tags)
         if include_all_tags:
             if not set(include_all_tags).issubset(tags_set):
+                logger.trace(f"Tag check failed: missing required include_all_tags {set(include_all_tags) - tags_set}.")
                 return False
         if include_any_tags:
             if not set(include_any_tags).intersection(tags_set):
+                logger.trace(f"Tag check failed: none of include_any_tags {set(include_any_tags)} present.")
                 return False
         if exclude_all_tags:
             if set(exclude_all_tags).issubset(tags_set):
+                logger.trace(f"Tag check failed: all exclude_all_tags {set(exclude_all_tags)} present.")
                 return False
         if exclude_any_tags:
             if set(exclude_any_tags).intersection(tags_set):
+                logger.trace(f"Tag check failed: matched excluded tag(s) {set(exclude_any_tags).intersection(tags_set)}.")
                 return False
         return True
 
@@ -554,6 +558,7 @@ class ShareLimits:
         """Check if the torrent has the required category"""
         if categories:
             if category not in categories:
+                logger.trace(f"Category check failed: '{category}' not in allowed categories {categories}.")
                 return False
         return True
 
@@ -565,7 +570,7 @@ class ShareLimits:
 
         size = self._get_torrent_size_bytes(torrent)
         if size is None:
-            logger.trace(f"Unable to determine size for torrent: {torrent.name}. Excluding from size-filtered groups.")
+            # _get_torrent_size_bytes already logs why the size could not be determined.
             return False
 
         if min_size is not None and size < int(min_size):
@@ -587,8 +592,8 @@ class ShareLimits:
                 val = getattr(torrent, attr, None)
                 if val is not None:
                     return int(val)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.trace(f"Could not read '{attr}' size attribute for torrent '{torrent.name}': {e}")
 
         # Fallback: sum file sizes if available
         try:
@@ -602,9 +607,13 @@ class ShareLimits:
                     continue
             if total > 0:
                 return total
-        except Exception:
-            pass
+        except Exception as e:
+            logger.trace(f"Could not sum file sizes for torrent '{torrent.name}': {e}")
 
+        logger.debug(
+            f"Unable to determine size for torrent '{torrent.name}'; it will be excluded from any "
+            "size-filtered share-limit groups (min_torrent_size / max_torrent_size)."
+        )
         return None
 
     def set_limits(

--- a/modules/core/share_limits.py
+++ b/modules/core/share_limits.py
@@ -330,38 +330,29 @@ class ShareLimits:
         hash_not_prev_checked,
         share_limits_not_yet_tagged,
     ):
-        """Log detailed trace information for a torrent"""
-        logger.trace(f"Torrent: {t_name} [Hash: {t_hash}]")
-        logger.trace(f"Torrent Category: {torrent.category}")
-        logger.trace(f"Torrent Tags: {torrent.tags}")
-        logger.trace(f"Grouping: {group_name}")
-        logger.trace(f"Config Max Ratio vs Torrent Max Ratio:{group_config['max_ratio']} vs {torrent.ratio_limit}")
-        logger.trace(f"check_max_ratio: {check_max_ratio}")
+        """Log detailed trace information for a torrent as a single grouped record (was ~18 separate
+        trace lines per torrent, which made share-limit decisions hard to follow)."""
+        max_seed = group_config["max_seeding_time"]
+        min_seed = group_config["min_seeding_time"]
         logger.trace(
-            "Config Max Seeding Time vs Torrent Max Seeding Time (minutes): "
-            f"{group_config['max_seeding_time']} vs {torrent.seeding_time_limit}"
+            f"Evaluating share limits for torrent '{t_name}' [Hash: {t_hash}]\n"
+            f"    Category: {torrent.category} | Tags: {torrent.tags} | Grouping: {group_name}\n"
+            f"    Max Ratio (config vs torrent): {group_config['max_ratio']} vs {torrent.ratio_limit} "
+            f"-> check_max_ratio={check_max_ratio}\n"
+            f"    Max Seeding Time (config vs torrent limit, minutes): {max_seed} vs {torrent.seeding_time_limit}\n"
+            f"    Max Seeding Time (config vs current, minutes): {max_seed} vs {torrent.seeding_time / 60} "
+            f"[{timedelta(minutes=max_seed)} vs {timedelta(seconds=torrent.seeding_time)}]\n"
+            f"    Min Seeding Time (config vs current, minutes): {min_seed} vs {torrent.seeding_time / 60} "
+            f"[{timedelta(minutes=min_seed)} vs {timedelta(seconds=torrent.seeding_time)}] "
+            f"-> check_max_seeding_time={check_max_seeding_time}\n"
+            f"    Min Num Seeds (config vs torrent): {group_config['min_num_seeds']} vs {torrent.num_complete}\n"
+            f"    Limit Upload Speed (config vs torrent): {group_config['limit_upload_speed']} vs {torrent_upload_limit} "
+            f"-> check_limit_upload_speed={check_limit_upload_speed}\n"
+            f"    upload_speed_on_limit_reached={group_config['upload_speed_on_limit_reached']}\n"
+            f"    hash_not_prev_checked={hash_not_prev_checked} | "
+            f"share_limits_not_yet_tagged={share_limits_not_yet_tagged} | "
+            f"check_multiple_share_limits_tag={is_tag_in_torrent(self.share_limits_tag, torrent.tags, exact=False)}"
         )
-        logger.trace(
-            "Config Max Seeding Time vs Torrent Current Seeding Time (minutes): "
-            f"({group_config['max_seeding_time']} vs {torrent.seeding_time / 60}) "
-            f"{str(timedelta(minutes=group_config['max_seeding_time']))} vs {str(timedelta(seconds=torrent.seeding_time))}"
-        )
-        logger.trace(
-            "Config Min Seeding Time vs Torrent Current Seeding Time (minutes): "
-            f"({group_config['min_seeding_time']} vs {torrent.seeding_time / 60}) "
-            f"{str(timedelta(minutes=group_config['min_seeding_time']))} vs {str(timedelta(seconds=torrent.seeding_time))}"
-        )
-        logger.trace(f"Config Min Num Seeds vs Torrent Num Seeds: {group_config['min_num_seeds']} vs {torrent.num_complete}")
-        logger.trace(f"check_max_seeding_time: {check_max_seeding_time}")
-        logger.trace(
-            "Config Limit Upload Speed vs Torrent Limit Upload Speed: "
-            f"{group_config['limit_upload_speed']} vs {torrent_upload_limit}"
-        )
-        logger.trace(f"check_limit_upload_speed: {check_limit_upload_speed}")
-        logger.trace(f"upload_speed_on_limit_reached: {group_config['upload_speed_on_limit_reached']}")
-        logger.trace(f"hash_not_prev_checked: {hash_not_prev_checked}")
-        logger.trace(f"share_limits_not_yet_tagged: {share_limits_not_yet_tagged}")
-        logger.trace(f"check_multiple_share_limits_tag: {is_tag_in_torrent(self.share_limits_tag, torrent.tags, exact=False)}")
 
     def _should_update_torrent(
         self,

--- a/modules/core/tag_nohardlinks.py
+++ b/modules/core/tag_nohardlinks.py
@@ -100,6 +100,7 @@ class TagNoHardLinks:
         )
         if any(util.is_tag_in_torrent(tag, torrent.tags) for tag in exclude_tags):
             # Skip to the next torrent if we find any torrents that are in the exclude tag
+            logger.debug(f"Torrent '{torrent.name}' has an excluded tag ({exclude_tags}); skipping nohardlinks tagging.")
             return has_nohardlinks
         else:
             # Checks for any hardlinks and not already tagged

--- a/modules/core/tag_nohardlinks.py
+++ b/modules/core/tag_nohardlinks.py
@@ -38,7 +38,8 @@ class TagNoHardLinks:
         """Add tag nohardlinks_tag to torrents with no hardlinks"""
         body = []
         body.append(logger.insert_space(f"Torrent Name: {torrent.name}", 3))
-        body.append(logger.insert_space(f"Added Tag: {self.nohardlinks_tag}", 6))
+        tag_action = "Not Adding Tag (Dry-Run)" if self.config.dry_run else "Added Tag"
+        body.append(logger.insert_space(f"{tag_action}: {self.nohardlinks_tag}", 6))
         title = "Tagging Torrents with No Hardlinks"
         body.append(logger.insert_space(f"Tracker: {tracker['url']}", 8))
         if not self.config.dry_run:
@@ -71,7 +72,8 @@ class TagNoHardLinks:
                 f"Previous Tagged {self.nohardlinks_tag} Torrent Name: {torrent.name} has hardlinks found now.",
                 self.config.loglevel,
             )
-            body += logger.print_line(logger.insert_space(f"Removed Tag: {self.nohardlinks_tag}", 6), self.config.loglevel)
+            tag_action = "Not Removing Tag (Dry-Run)" if self.config.dry_run else "Removed Tag"
+            body += logger.print_line(logger.insert_space(f"{tag_action}: {self.nohardlinks_tag}", 6), self.config.loglevel)
             body += logger.print_line(logger.insert_space(f"Tracker: {tracker['url']}", 8), self.config.loglevel)
             if not self.config.dry_run:
                 torrent.remove_tags(tags=self.nohardlinks_tag)

--- a/modules/core/tag_nohardlinks.py
+++ b/modules/core/tag_nohardlinks.py
@@ -98,7 +98,7 @@ class TagNoHardLinks:
         )
         if any(util.is_tag_in_torrent(tag, torrent.tags) for tag in exclude_tags):
             # Skip to the next torrent if we find any torrents that are in the exclude tag
-            return
+            return has_nohardlinks
         else:
             # Checks for any hardlinks and not already tagged
             # Cleans up previously tagged nohardlinks_tag torrents that no longer have hardlinks
@@ -111,6 +111,7 @@ class TagNoHardLinks:
                         category=category,
                     )
         self.check_previous_nohardlinks_tagged_torrents(has_nohardlinks, torrent, tracker, category)
+        return has_nohardlinks
 
     def tag_nohardlinks(self):
         """Tag torrents with no hardlinks"""
@@ -121,14 +122,23 @@ class TagNoHardLinks:
 
         if self.hashes:
             torrent_list = self.qbt.get_torrents({"torrent_hashes": self.hashes, "status_filter": self.status_filter})
+            logger.debug(f"Checking {len(torrent_list)} torrent(s) from supplied hashes for hardlinks.")
+            checked = 0
+            no_hardlinks = 0
             for torrent in torrent_list:
-                self._process_torrent_for_nohardlinks(
+                checked += 1
+                if self._process_torrent_for_nohardlinks(
                     torrent,
                     check_hardlinks,
                     nohardlinks.get(torrent.category, {}).get("ignore_root_dir", True),
                     nohardlinks.get(torrent.category, {}).get("exclude_tags", []),
                     torrent.category,
-                )
+                ):
+                    no_hardlinks += 1
+            logger.print_line(
+                f"Checked {checked} torrent{'s' if checked != 1 else ''}, {no_hardlinks} with no hardlinks.",
+                self.config.loglevel,
+            )
         else:
             for category in nohardlinks:
                 torrent_list = self.qbt.get_torrents({"category": category, "status_filter": self.status_filter})
@@ -141,14 +151,25 @@ class TagNoHardLinks:
                     )
                     logger.warning(ex)
                     continue
+                logger.debug(f"Checking {len(torrent_list)} torrent(s) in category '{category}' for hardlinks.")
+                category_checked = 0
+                category_no_hardlinks = 0
                 for torrent in torrent_list:
-                    self._process_torrent_for_nohardlinks(
+                    category_checked += 1
+                    if self._process_torrent_for_nohardlinks(
                         torrent,
                         check_hardlinks,
                         nohardlinks.get(category, {}).get("ignore_root_dir", True),
                         nohardlinks.get(category, {}).get("exclude_tags", []),
                         category,
-                    )
+                    ):
+                        category_no_hardlinks += 1
+                logger.print_line(
+                    f"Category '{category}': checked {category_checked} "
+                    f"torrent{'s' if category_checked != 1 else ''}, "
+                    f"{category_no_hardlinks} with no hardlinks.",
+                    self.config.loglevel,
+                )
         if self.stats_tagged >= 1:
             logger.print_line(
                 f"{'Did not Tag' if self.config.dry_run else 'Added Tag'} for {self.stats_tagged} "

--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -246,19 +246,21 @@ class Qbt:
         t_hash = torrent.hash
         t_name = torrent.name
         if torrent.downloaded != 0:
-            logger.trace(f"Torrent: {t_name} [Hash: {t_hash}] is not a cross seeded torrent. Download is > 0.")
+            logger.trace(f"Torrent: {t_name} [Hash: {t_hash}] is not a cross seed (downloaded > 0).")
             return False
         cross_seed = True
+        reason = "all files are cross-seeded copies of existing data"
         for file in torrent.files:
             full_path = os.path.join(torrent.save_path, file.name)
             if self.torrentfiles[full_path]["original"] == t_hash or t_hash not in self.torrentfiles[full_path]["cross_seed"]:
-                logger.trace(f"File: [{full_path}] is found in Torrent: {t_name} [Hash: {t_hash}] as the original torrent")
                 cross_seed = False
+                reason = f"file '{full_path}' belongs to this torrent as the original"
                 break
             elif self.torrentfiles[full_path]["original"] is None:
                 cross_seed = False
+                reason = f"file '{full_path}' has no original torrent"
                 break
-        logger.trace(f"Torrent: {t_name} [Hash: {t_hash}] {'is' if cross_seed else 'is not'} a cross seed torrent.")
+        logger.trace(f"Torrent: {t_name} [Hash: {t_hash}] {'is' if cross_seed else 'is not'} a cross seed ({reason}).")
         return cross_seed
 
     def has_cross_seed(self, torrent):
@@ -266,13 +268,19 @@ class Qbt:
         cross_seed = False
         t_hash = torrent.hash
         t_name = torrent.name
+        matched_file = None
+        cross_seeds = None
         for file in torrent.files:
             full_path = os.path.join(torrent.save_path, file.name)
             if len(self.torrentfiles[full_path]["cross_seed"]) > 0:
-                logger.trace(f"{full_path} has cross seeds: {self.torrentfiles[full_path]['cross_seed']}")
                 cross_seed = True
+                matched_file = full_path
+                cross_seeds = self.torrentfiles[full_path]["cross_seed"]
                 break
-        logger.trace(f"Torrent: {t_name} [Hash: {t_hash}] {'has' if cross_seed else 'has no'} cross seeds.")
+        if cross_seed:
+            logger.trace(f"Torrent: {t_name} [Hash: {t_hash}] has cross seeds (file '{matched_file}' shared with {cross_seeds}).")
+        else:
+            logger.trace(f"Torrent: {t_name} [Hash: {t_hash}] has no cross seeds.")
         return cross_seed
 
     def remove_torrent_files(self, torrent):
@@ -289,9 +297,11 @@ class Qbt:
             else:
                 if torrent_hash in self.torrentfiles[full_path]["cross_seed"]:
                     self.torrentfiles[full_path]["cross_seed"].remove(torrent_hash)
-                    logger.trace(f"Removed {torrent_hash} from {full_path} cross seeds")
-                    logger.trace(f"{full_path} original: {self.torrentfiles[full_path]['original']}")
-                    logger.trace(f"{full_path} cross seeds: {self.torrentfiles[full_path]['cross_seed']}")
+                    logger.trace(
+                        f"Removed {torrent_hash} from {full_path} cross seeds | "
+                        f"original: {self.torrentfiles[full_path]['original']} | "
+                        f"cross seeds: {self.torrentfiles[full_path]['cross_seed']}"
+                    )
 
     def get_torrents(self, params):
         """Get torrents from qBittorrent"""

--- a/modules/util.py
+++ b/modules/util.py
@@ -1125,6 +1125,9 @@ class CheckHardLinks:
                     self.inode_count[inode_no] += 1
                 else:
                     self.inode_count[inode_no] = 1
+        logger.debug(
+            f"Built inode count from {len(self.root_files)} file(s) in root_dir ({len(self.inode_count)} unique inode(s))."
+        )
 
     def nohardlink(self, file, notify, ignore_root_dir):
         """
@@ -1135,21 +1138,21 @@ class CheckHardLinks:
         This fixes the bug in #192
         """
 
-        def has_hardlinks(self, file, ignore_root_dir):
+        def has_hardlinks(file_stat, ignore_root_dir):
             """
             Check if a file has hard links.
 
             Args:
-                file (str): The path to the file.
-                ignore_root_dir (bool): Whether to ignore the root directory.
+                file_stat (os.stat_result): The cached stat result of the file.
+                ignore_root_dir (bool): Whether to ignore links that live inside root_dir.
 
             Returns:
                 bool: True if the file has hard links, False otherwise.
             """
             if ignore_root_dir:
-                return os.stat(file).st_nlink - self.inode_count.get(os.stat(file).st_ino, 1) > 0
+                return file_stat.st_nlink - self.inode_count.get(file_stat.st_ino, 1) > 0
             else:
-                return os.stat(file).st_nlink > 1
+                return file_stat.st_nlink > 1
 
         check_for_hl = True
         try:
@@ -1157,19 +1160,24 @@ class CheckHardLinks:
                 if os.path.islink(file):
                     logger.warning(f"Symlink found in {file}, unable to determine hardlinks. Skipping...")
                     return False
-                logger.trace(f"Checking file: {file}")
-                logger.trace(f"Checking file inum: {os.stat(file).st_ino}")
-                logger.trace(f"Checking no of hard links: {os.stat(file).st_nlink}")
-                logger.trace(f"Checking inode_count dict: {self.inode_count.get(os.stat(file).st_ino)}")
-                logger.trace(f"ignore_root_dir: {ignore_root_dir}")
+                file_stat = os.stat(file)
+                inode_count = self.inode_count.get(file_stat.st_ino, 1)
+                # Single compact trace line per file instead of one line per attribute (was too spammy).
+                logger.trace(
+                    f"Checking file '{file}' | inode: {file_stat.st_ino} | nlink: {file_stat.st_nlink} | "
+                    f"links inside root_dir: {inode_count} | ignore_root_dir: {ignore_root_dir}"
+                )
                 # https://github.com/StuffAnThings/qbit_manage/issues/291 for more details
-                if has_hardlinks(self, file, ignore_root_dir):
-                    logger.trace(f"Hardlinks found in {file}.")
+                if has_hardlinks(file_stat, ignore_root_dir):
                     check_for_hl = False
+                    logger.debug(
+                        f"Hardlinks found for '{file}': nlink={file_stat.st_nlink}, links inside root_dir={inode_count}, "
+                        f"ignore_root_dir={ignore_root_dir}."
+                    )
+                else:
+                    logger.debug(f"No hardlinks found for '{file}' (nlink={file_stat.st_nlink}).")
             else:
                 sorted_files = sorted(Path(file).rglob("*"), key=lambda x: os.stat(x).st_size, reverse=True)
-                logger.trace(f"Folder: {file}")
-                logger.trace(f"Files Sorted by size: {sorted_files}")
                 threshold = 0.1
                 if not sorted_files:
                     msg = (
@@ -1180,23 +1188,41 @@ class CheckHardLinks:
                     logger.warning(msg)
                 else:
                     largest_file_size = os.stat(sorted_files[0]).st_size
-                    logger.trace(f"Largest file: {sorted_files[0]}")
-                    logger.trace(f"Largest file size: {largest_file_size}")
+                    size_threshold = largest_file_size * threshold
+                    logger.trace(
+                        f"Checking folder '{file}' | files: {len(sorted_files)} | "
+                        f"largest file: '{sorted_files[0]}' ({largest_file_size} bytes) | "
+                        f"only checking files >= {threshold:.0%} of largest ({size_threshold:.0f} bytes)"
+                    )
                     for files in sorted_files:
                         if os.path.islink(files):
                             logger.warning(f"Symlink found in {files}, unable to determine hardlinks. Skipping...")
                             continue
-                        file_size = os.stat(files).st_size
-                        file_no_hardlinks = os.stat(files).st_nlink
-                        logger.trace(f"Checking file: {files}")
-                        logger.trace(f"Checking file inum: {os.stat(files).st_ino}")
-                        logger.trace(f"Checking file size: {file_size}")
-                        logger.trace(f"Checking no of hard links: {file_no_hardlinks}")
-                        logger.trace(f"Checking inode_count dict: {self.inode_count.get(os.stat(files).st_ino)}")
-                        logger.trace(f"ignore_root_dir: {ignore_root_dir}")
-                        if has_hardlinks(self, files, ignore_root_dir) and file_size >= (largest_file_size * threshold):
-                            logger.trace(f"Hardlinks found in {files}.")
+                        file_stat = os.stat(files)
+                        file_size = file_stat.st_size
+                        # sorted_files is sorted by size descending, so once we drop below the threshold no
+                        # remaining file can qualify -> stop checking (avoids checking/logging every small file).
+                        if file_size < size_threshold:
+                            logger.trace(
+                                f"Skipping remaining files in '{file}': '{files}' ({file_size} bytes) and smaller "
+                                f"are below the {threshold:.0%} size threshold."
+                            )
+                            break
+                        inode_count = self.inode_count.get(file_stat.st_ino, 1)
+                        logger.trace(
+                            f"Checking file '{files}' | size: {file_size} | inode: {file_stat.st_ino} | "
+                            f"nlink: {file_stat.st_nlink} | links inside root_dir: {inode_count} | "
+                            f"ignore_root_dir: {ignore_root_dir}"
+                        )
+                        if has_hardlinks(file_stat, ignore_root_dir):
                             check_for_hl = False
+                            logger.debug(
+                                f"Hardlinks found in folder '{file}' for file '{files}': nlink={file_stat.st_nlink}, "
+                                f"links inside root_dir={inode_count}, ignore_root_dir={ignore_root_dir}."
+                            )
+                            break
+                    if check_for_hl:
+                        logger.debug(f"No hardlinks found in folder '{file}'.")
         except PermissionError as perm:
             logger.warning(f"{perm} : file {file} has permission issues. Skipping...")
             return False


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

## Summary

Trace logging in the no-hardlink check (and share-limits evaluation) was too
spammy to troubleshoot with, there was no `debug`-level output explaining *why*
a torrent was determined to have / not have hardlinks, and some dry-run messages
were misleading. This makes the hardlink decision path actually debuggable
without changing any tagging behaviour.

## Changes

### `nohardlink()` / `CheckHardLinks` (`modules/util.py`)
- **TRACE de-spammed:** the ~6 trace lines emitted per file are collapsed into a
  single compact line. On a large folder this was hundreds of records.
- **Folders stop early:** files are size-sorted descending and only those at/above
  the size threshold matter, so once we drop below it we stop (one "skipping
  remaining" line) and we break on the first qualifying hardlink found.
- **DEBUG decisions added** — the real troubleshooting win. Each result states
  *why*, e.g.
  `Hardlinks found for '<file>': nlink=2, links inside root_dir=1, ignore_root_dir=True.`
  This makes the otherwise-invisible inode-count interaction observable.
- `get_inode_count()` logs a one-line debug summary (files scanned / unique inodes).
- Cached `os.stat()` per file instead of re-stat-ing it 5+ times.
- Symlink warnings unchanged.

### `tag_nohardlinks.py`
- Per-category **INFO summary** so a normal run shows the outcome without `--debug`:
  `Category 'movies': checked 50 torrents, 3 with no hardlinks.`
  Same summary for the hash-filtered path (`_process_torrent_for_nohardlinks` now
  returns the result).
- **Dry-run-aware messages:** the per-torrent body lines previously said
  `Added Tag` / `Removed Tag` even during `--dry-run` when nothing changed (and
  that text is also sent to notifiarr/apprise). They now read
  `Not Adding Tag (Dry-Run)` / `Not Removing Tag (Dry-Run)`, consistent with the
  existing summary wording.

### `share_limits.py`
- Consolidated the ~18 separate `logger.trace()` lines per torrent in
  `_log_torrent_trace` into a single grouped, readable record.

## Behaviour
Logging/output only — no functional or tagging change. The folder early-exit is
an optimization with identical results (files are size-sorted descending).

## Testing
- `ruff check` + `ruff format`: clean
- Full test suite: **327 passed**
- Smoke-tested all `nohardlink` paths (single / folder / symlink / hardlinked,
  both `ignore_root_dir` values) — results identical to before


## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have modified this PR to merge to the develop branch
