### PR TITLE
feat(scripts): add CA bundle option to mover

### DIFF
--- a/scripts/mover.py
+++ b/scripts/mover.py
@@ -23,6 +23,11 @@ parser.add_argument("--host", help="qbittorrent host including port", required=T
 parser.add_argument("-u", "--user", help="qbittorrent user", default="admin")
 parser.add_argument("-p", "--password", help="qbittorrent password", default="adminadmin")
 parser.add_argument(
+    "--ca-bundle",
+    help="Path to a CA bundle used to verify the qBittorrent WebUI HTTPS certificate",
+    default=None,
+)
+parser.add_argument(
     "--cache-mount",
     "--cache_mount",
     help="Cache mount point in Unraid. This is used to additionally filter for only torrents that exists on the cache mount."
@@ -189,6 +194,10 @@ if __name__ == "__main__":
     current = datetime.now()
     args = parser.parse_args()
 
+    if args.ca_bundle and not os.path.isfile(args.ca_bundle):
+        logging.error(f"CA bundle not found: {args.ca_bundle}")
+        sys.exit(1)
+
     # If no specific operation is requested, default to all operations (original behavior)
     if not any([args.pause, args.resume, args.move]):
         args.pause = True
@@ -204,7 +213,16 @@ if __name__ == "__main__":
 
     if args.pause or args.resume:
         try:
-            client = Client(host=args.host, username=args.user, password=args.password)
+            client_kwargs = {
+                "host": args.host,
+                "username": args.user,
+                "password": args.password,
+            }
+
+            if args.ca_bundle:
+                client_kwargs["REQUESTS_ARGS"] = {"verify": args.ca_bundle}
+
+            client = Client(**client_kwargs)
         except LoginFailed:
             raise ("Qbittorrent Error: Failed to login. Invalid username/password.")
         except APIConnectionError:


### PR DESCRIPTION
## Note

Sorry for the duplicate/closed PR #1252. I accidentally created it from VS Code against `master` without a description, so I closed it and reopened this one correctly against `develop`.

## Description

Adds a `--ca-bundle` option to `scripts/mover.py` so users can provide a custom CA bundle for verifying the qBittorrent WebUI HTTPS certificate.

This allows installations with a private/self-signed CA to configure certificate verification for the qBittorrent API connection without relying on global environment variables such as `REQUESTS_CA_BUNDLE` or `SSL_CERT_FILE`.

Fixes # N/A

## Type of change

* [x] New feature (non-breaking change which adds functionality)

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have added or updated the docstring for new or existing methods
* [x] I have modified this PR to merge to the develop branch

## Testing

* [x] `python -m py_compile scripts/mover.py`
* [x] `make pre-commit`
* [x] `pytest tests/ --no-cov`

Result: `327 passed`

## Related

Related TRaSH-Guides PR: https://github.com/TRaSH-Guides/Guides/pull/2772
