### PR TITLE
ci: gate publish jobs to upstream + add smart triggers

### DIFF
--- a/.github/workflows/bump-version-develop.yml
+++ b/.github/workflows/bump-version-develop.yml
@@ -21,8 +21,10 @@ permissions:
 
 jobs:
   bump:
-    # Skip when a commit explicitly opts out of another version bump.
+    # Skip when a commit explicitly opts out of another version bump, and
+    # skip entirely on forks (BOT_TOKEN won't be configured there).
     if: >-
+      github.repository == 'StuffAnThings/qbit_manage' &&
       github.actor != 'github-actions[bot]' &&
       !contains(github.event.head_commit.message, '[skip-version-bump]')
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-approve-and-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-auto-merge.yml
@@ -16,9 +16,9 @@ jobs:
   dependabot:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Checking the actor will prevent your Action run failing on non-Dependabot
-    # PRs but also ensures that it only does work for Dependabot PRs.
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    # Upstream-only: forks shouldn't auto-approve/merge on the upstream's
+    # behalf. Actor check keeps non-dependabot PRs from running the job.
+    if: ${{ github.repository == 'StuffAnThings/qbit_manage' && github.actor == 'dependabot[bot]' }}
     steps:
       # This first step will fail if there's no metadata and so the approval
       # will not occur.

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -3,6 +3,18 @@ name: Docker Develop Release
 on:
   push:
     branches: [develop]
+    paths-ignore:
+      # Skip the full 5-OS PyInstaller + Tauri matrix on doc-only / template-only
+      # commits. Use workflow_dispatch to force a manual rebuild if a docs change
+      # needs to land in the bundled artifact.
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/FUNDING.yml'
+      - '.github/pull_request_template.md'
+      - '.github/labeler.yml'
+      - 'CHANGELOG'
+      - 'LICENSE'
   workflow_dispatch:
 
 concurrency:
@@ -12,6 +24,8 @@ concurrency:
 jobs:
   build-binaries:
     name: Build Standalone Binaries (${{ matrix.os }})
+    # Upstream-only: forks shouldn't burn ~5 OS-runners on every develop push.
+    if: github.repository == 'StuffAnThings/qbit_manage'
     permissions:
       contents: read
     runs-on: ${{ matrix.os }}
@@ -377,6 +391,8 @@ jobs:
 
   docker-develop:
     runs-on: ubuntu-latest
+    # Upstream-only: DOCKER_HUB_USERNAME / GHCR_TOKEN aren't configured on forks.
+    if: github.repository == 'StuffAnThings/qbit_manage'
 
     steps:
       - name: set lower case owner name

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   job-sync-docs-to-wiki:
     runs-on: ubuntu-latest
-    if: github.event_name != 'gollum'
+    if: github.event_name != 'gollum' && github.repository == 'StuffAnThings/qbit_manage'
     timeout-minutes: 10
     permissions:
       contents: read
@@ -42,7 +42,7 @@ jobs:
 
   job-sync-wiki-to-docs:
     runs-on: ubuntu-latest
-    if: github.event_name == 'gollum'
+    if: github.event_name == 'gollum' && github.repository == 'StuffAnThings/qbit_manage'
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -23,6 +23,8 @@ jobs:
   label-conflicts:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Upstream-only: the conflict label only exists on upstream's tracker.
+    if: github.repository == 'StuffAnThings/qbit_manage'
     steps:
       - name: Label PRs with merge conflicts
         uses: eps1lon/actions-label-merge-conflict@v3

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -18,6 +18,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: github.repository == 'StuffAnThings/qbit_manage'
     steps:
       - uses: dessant/lock-threads@v6
         with:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,6 +20,8 @@ jobs:
   pypi-publish:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Upstream-only: PyPI trusted publisher is configured on the upstream repo.
+    if: github.repository == 'StuffAnThings/qbit_manage'
     permissions:
       contents: read
       id-token: write  # Required for trusted publishing to PyPI

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -42,6 +42,8 @@ jobs:
     name: Prepare release branch
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Upstream-only: writes release/* branches against the upstream repo.
+    if: github.repository == 'StuffAnThings/qbit_manage'
     outputs:
       new_version: ${{ steps.compute.outputs.new_version }}
       current_version: ${{ steps.compute.outputs.current_version }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -15,6 +15,8 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Upstream-only: PAT secret writes tags on the upstream repo.
+    if: github.repository == 'StuffAnThings/qbit_manage'
     steps:
 
       - uses: actions/checkout@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,11 +6,34 @@ on:
       - master
       - main
       - develop
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/FUNDING.yml'
+      - '.github/pull_request_template.md'
+      - 'icons/**'
+      - 'CHANGELOG'
+      - 'LICENSE'
   pull_request:
     branches:
       - master
       - main
       - develop
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/FUNDING.yml'
+      - '.github/pull_request_template.md'
+      - 'icons/**'
+      - 'CHANGELOG'
+      - 'LICENSE'
+
+concurrency:
+  # Cancel in-flight runs when a new push lands on the same PR / branch.
+  group: tests-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,12 @@ on:
 
 concurrency:
   # Cancel in-flight runs when a new push lands on the same PR / branch.
-  group: tests-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  # Use github.ref directly: for PR events it's `refs/pull/<num>/merge`
+  # (unique per PR even across forks with the same head branch name);
+  # for push events it's `refs/heads/<branch>` (unique per branch).
+  # `head_ref` would be just the branch name — two PRs both named e.g.
+  # `patch-1` would cancel each other.
+  group: tests-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/update-develop-branch.yml
+++ b/.github/workflows/update-develop-branch.yml
@@ -16,6 +16,8 @@ jobs:
   update-develop:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Upstream-only: force-pushes develop on the upstream repo.
+    if: github.repository == 'StuffAnThings/qbit_manage'
 
     steps:
       - name: Check Out Repo

--- a/.github/workflows/update-supported-versions.yml
+++ b/.github/workflows/update-supported-versions.yml
@@ -26,6 +26,8 @@ jobs:
   update-versions:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Upstream-only: opens PR to upstream's develop.
+    if: github.repository == 'StuffAnThings/qbit_manage'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   build-binaries:
     name: Build Standalone Binaries (${{ matrix.os }})
+    # Upstream-only: forks shouldn't run the full release matrix on every tag.
+    if: github.repository == 'StuffAnThings/qbit_manage'
     permissions:
       contents: read
     runs-on: ${{ matrix.os }}
@@ -405,6 +407,8 @@ jobs:
 
   docker-release:
     runs-on: ubuntu-latest
+    # Upstream-only: DOCKER_HUB_USERNAME / GHCR_TOKEN aren't configured on forks.
+    if: github.repository == 'StuffAnThings/qbit_manage'
 
     steps:
       - name: set lower case owner name

--- a/desktop/tauri/src-tauri/Cargo.lock
+++ b/desktop/tauri/src-tauri/Cargo.lock
@@ -748,7 +748,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -4246,12 +4245,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -4261,15 +4259,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
## Summary

Forks of qbit_manage hit a wall of red checks because publish jobs (Docker
Hub, GHCR, PyPI, GH releases, wiki sync, `develop` force-push, etc.) try
to run with secrets that only exist on the canonical upstream repo. This
PR makes those jobs no-op on forks and adds a couple of cheap CI-speed
wins along the way.

### Gated to upstream only

Every job whose work only makes sense on `StuffAnThings/qbit_manage` now
guards with `if: github.repository == 'StuffAnThings/qbit_manage'`:

| Workflow | Why upstream-only |
|---|---|
| `bump-version-develop` | `BOT_TOKEN` writes VERSION |
| `develop` (build-binaries + docker-develop) | 5-OS PyInstaller + Tauri matrix; Docker Hub / GHCR push |
| `version` (build-binaries + docker-release) | release matrix + Docker push + GH release |
| `pypi-publish` | PyPI trusted publisher |
| `release-pr` (prepare-release-branch) | writes `release/*` branches |
| `tag` | PAT-driven tag writer |
| `update-develop-branch` | force-pushes `develop` to match master |
| `update-supported-versions` | opens PR to upstream's `develop` |
| `docs` (both jobs) | wiki ↔ docs sync, PAT |
| `lock-threads` | issue locker |
| `label-conflicts` | push side (PR side already upstream-only via `pull_request_target`) |
| `dependabot-approve-and-auto-merge` | belt-and-suspenders alongside the existing actor gate |

Job-level gates skip transitively — downstream jobs with `needs:` chains
fall away automatically once the head job skips.

### Smart triggers (CI speed)

- **`tests.yml`** — added `concurrency: cancel-in-progress: true` so PR
  re-pushes cancel the in-flight pytest matrix; added `paths-ignore` for
  doc-only / template-only / icon-only paths so README touches don't burn
  the 3-version pytest matrix.
- **`develop.yml`** — added `paths-ignore` for doc-only / template-only
  paths so the 5-OS PyInstaller + Tauri matrix + Docker push doesn't fire
  on doc syncs. `workflow_dispatch` remains for manual rebuilds.

### Untouched (intentionally fork-safe already)

- `tests.yml` itself — only checks out + runs pytest, no secrets.
- `secrets-scan.yml` — pure Python passkey scan, no secrets used.
- `labeler.yml` — only `pull_request_target`, already upstream-side.

## Test plan

- [x] All 13 modified workflows parse as valid YAML (`yaml.safe_load`).
- [x] No publish job loses its trigger on upstream (gates use `==`, not a flag exclusion).
- [ ] After merge: verify a fork PR's checks page shows only `tests` + `secrets-scan` + `labeler` running.
- [ ] After merge: verify upstream `tests` still runs on next push to `develop`.