### PR TITLE
ci: Clearer workflow and check names

### DIFF
--- a/.github/workflows/bump-version-develop.yml
+++ b/.github/workflows/bump-version-develop.yml
@@ -1,4 +1,5 @@
-name: Bump develop VERSION
+# Bumps the -developN suffix in VERSION on every push to develop, avoiding per-PR rebase conflicts.
+name: Bump Develop VERSION
 
 # Auto-increments the `-developN` suffix in VERSION on every push to develop
 # (typically a PR merge). Replaces the per-PR-commit pre-commit hook so that

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,3 +1,4 @@
+# Builds binaries and Docker image for the develop branch on every push or manual trigger.
 name: Docker Develop Release
 
 on:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,4 @@
+# Syncs docs/ ↔ GitHub Wiki bidirectionally on doc pushes (docs→wiki) or wiki edits (wiki→docs).
 name: Documentation
 
 on:
@@ -21,7 +22,7 @@ env:
   GIT_AUTHOR_EMAIL: actions@github.com
 
 jobs:
-  job-sync-docs-to-wiki:
+  sync-docs-to-wiki:
     runs-on: ubuntu-latest
     if: github.event_name != 'gollum' && github.repository == 'StuffAnThings/qbit_manage'
     timeout-minutes: 10
@@ -40,7 +41,7 @@ jobs:
           gitAuthorName: ${{ env.GIT_AUTHOR_NAME }}
           gitAuthorEmail: ${{ env.GIT_AUTHOR_EMAIL }}
 
-  job-sync-wiki-to-docs:
+  sync-wiki-to-docs:
     runs-on: ubuntu-latest
     if: github.event_name == 'gollum' && github.repository == 'StuffAnThings/qbit_manage'
     timeout-minutes: 10

--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -1,3 +1,4 @@
+# Adds a 'conflict' label to PRs that have merge conflicts, on push to master/develop or PR events.
 name: Label Conflicting PRs
 
 on:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,3 +1,4 @@
+# Auto-applies labels to PRs based on changed file paths, on every PR open/sync/reopen.
 name: PR Labeler
 
 on:
@@ -13,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  label:
+  labeler:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,3 +1,4 @@
+# Locks closed issues, PRs, and discussions after 365 days of inactivity; runs daily at 06:00 UTC.
 name: Lock Closed Threads
 
 on:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,3 +1,4 @@
+# Publishes the package to PyPI (or Test PyPI) on version tag push or manual trigger.
 name: PyPI Publish
 
 on:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,3 +1,4 @@
+# Manually triggered: creates a release branch from develop, opens a PR to master, and drafts a GitHub release.
 name: Release PR
 
 # Creates a release branch (copy of develop), opens a PR to master, and

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,4 +1,4 @@
-name: secrets-scan
+name: Secrets Scan
 
 on:
   push:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,3 +1,4 @@
+# Tags the new version on every push to master using the VERSION file.
 name: Tag New Version
 
 on:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: tests
+name: Tests
 
 on:
   push:
@@ -45,6 +45,7 @@ permissions:
 
 jobs:
   pytest:
+    name: Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/update-develop-branch.yml
+++ b/.github/workflows/update-develop-branch.yml
@@ -1,3 +1,4 @@
+# Resets develop to master and bumps the develop VERSION suffix after every push to master.
 name: Update Develop Branch
 
 on:

--- a/.github/workflows/update-supported-versions.yml
+++ b/.github/workflows/update-supported-versions.yml
@@ -1,3 +1,4 @@
+# Updates SUPPORTED_VERSIONS.json and opens a PR to develop when pyproject.toml changes.
 name: Update Supported Versions
 
 on:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,3 +1,4 @@
+# Builds binaries, Docker image, and creates the GitHub release on every version tag push.
 name: Version Release
 
 on:


### PR DESCRIPTION
Makes the PR checks list easier to grok at a glance:

- `tests` → **Tests**; the matrix job now renders as **`Tests (Python 3.x)`** instead of `pytest (3.x)`.
- `secrets-scan` → **Secrets Scan** (consistent Title Case with the other workflows).

Display names only — no logic changes. Verified `develop` has no required-status-check rules (legacy protection 404; the only ruleset, *Copilot Review*, requires no checks), so renaming check contexts doesn't affect any merge gate.