### PR TITLE
ci: release-pr builds + publishes the draft release (reusable build, rolling develop prerelease, PR build artifacts)

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,0 +1,411 @@
+# Reusable build: standalone PyInstaller binaries + Tauri desktop bundles across
+# the 5-platform matrix, collected into a single `qbit-manage-release-assets`
+# artifact. Called by release-pr.yml, develop.yml, and pr-build.yml so the matrix
+# lives in exactly one place.
+name: Build Binaries (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref (branch / tag / sha) to check out and build"
+        required: true
+        type: string
+
+jobs:
+  build-binaries:
+    name: Build Standalone Binaries (${{ matrix.os }})
+    # Upstream-only: forks shouldn't burn ~5 OS-runners on a build.
+    if: github.repository == 'StuffAnThings/qbit_manage'
+    permissions:
+      contents: read
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python-version: "3.14"
+            arch: amd64
+          - os: ubuntu-24.04-arm # for Arm based Linux (Raspberry Pi, etc.)
+            python-version: "3.14"
+            arch: arm64
+          - os: windows-latest
+            python-version: "3.14"
+            arch: amd64
+          - os: "macos-latest" # for Arm based macs (M1 and above).
+            python-version: "3.14"
+            arch: arm64
+          - os: "macos-15-intel" # for Intel based macs.
+            python-version: "3.14"
+            arch: x86_64
+    env:
+      APP_NAME: qbit-manage
+      ENTRY: qbit_manage.py
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
+
+      - name: Upgrade Pip and install project + PyInstaller
+        run: |
+          python -m pip install --upgrade pip wheel
+          python -m pip install . pyinstaller
+
+      - name: Compute add-data separator
+        id: sep
+        shell: bash
+        run: |
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            echo "SEP=;" >> $GITHUB_OUTPUT
+          else
+            echo "SEP=:" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build (PyInstaller onefile)
+        shell: bash
+        run: |
+          ADD_WEBUI="web-ui${{ steps.sep.outputs.SEP }}web-ui"
+          ADD_SAMPLE_CFG="config/config.yml.sample${{ steps.sep.outputs.SEP }}config"
+          ADD_LOGO="icons/qbm_logo.png${{ steps.sep.outputs.SEP }}."
+          ADD_VERSION="VERSION${{ steps.sep.outputs.SEP }}."
+          ADD_DOCS="docs${{ steps.sep.outputs.SEP }}docs"
+          ICON_ARG=""
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            ICON_ARG=--icon=icons/qbm_logo.ico
+          elif [[ "${{ runner.os }}" == "macOS" ]]; then
+            ICON_ARG=--icon=icons/qbm_logo.icns
+          else
+            # Linux: optional icon (helps some desktop environments)
+            if [[ -f icons/qbm_logo.png ]]; then
+              ICON_ARG=--icon=icons/qbm_logo.png
+            elif [[ -f icons/qbm_logo.ico ]]; then
+              ICON_ARG=--icon=icons/qbm_logo.ico
+            fi
+          fi
+          pyinstaller --noconfirm \
+                      --clean \
+                      --onefile \
+                      --name "${APP_NAME}" \
+                      --add-data "$ADD_WEBUI" \
+                      --add-data "$ADD_SAMPLE_CFG" \
+                      --add-data "$ADD_LOGO" \
+                      --add-data "$ADD_VERSION" \
+                      --add-data "$ADD_DOCS" \
+                      $ICON_ARG \
+                      "${ENTRY}"
+
+      - name: Rename output for OS
+        shell: bash
+        run: |
+          mkdir -p out
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            mv "dist/${APP_NAME}.exe" "out/${APP_NAME}-windows-${{ matrix.arch }}.exe"
+          elif [[ "${{ runner.os }}" == "macOS" ]]; then
+            mv "dist/${APP_NAME}" "out/${APP_NAME}-macos-${{ matrix.arch }}"
+          else
+            mv "dist/${APP_NAME}" "out/${APP_NAME}-linux-${{ matrix.arch }}"
+          fi
+
+      # Build Tauri desktop shell after binaries are ready
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+        env:
+          RUSTUP_MAX_RETRIES: 10
+        timeout-minutes: 10
+        continue-on-error: true
+        id: rust-setup
+
+      - name: Wait before retry (network recovery)
+        if: steps.rust-setup.outcome == 'failure'
+        run: sleep 30
+        shell: bash
+
+      - name: Retry Rust toolchain setup on failure
+        if: steps.rust-setup.outcome == 'failure'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+        env:
+          RUSTUP_MAX_RETRIES: 10
+        timeout-minutes: 10
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            desktop/tauri/src-tauri -> desktop/tauri/src-tauri/target
+
+      - name: Install NSIS (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: choco install nsis -y
+
+      - name: Install Tauri dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          # Ubuntu 24.04 (noble) uses libwebkit2gtk-4.1-dev (4.0 no longer available)
+          # Install core deps first
+          sudo apt-get install -y libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf
+          # Try new package name, fall back for older runners
+          sudo apt-get install -y libwebkit2gtk-4.1-dev || sudo apt-get install -y libwebkit2gtk-4.0-dev
+
+      - name: Prepare Tauri server binary
+        shell: bash
+        run: |
+          mkdir -p desktop/tauri/src-tauri/bin
+
+          # Copy the actual binary for this platform as a resource
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cp "out/${APP_NAME}-windows-${{ matrix.arch }}.exe" "desktop/tauri/src-tauri/bin/qbit-manage-windows-${{ matrix.arch }}.exe"
+          elif [[ "${{ runner.os }}" == "macOS" ]]; then
+            cp "out/${APP_NAME}-macos-${{ matrix.arch }}" "desktop/tauri/src-tauri/bin/qbit-manage-macos-${{ matrix.arch }}"
+            chmod +x "desktop/tauri/src-tauri/bin/qbit-manage-macos-${{ matrix.arch }}"
+          else
+            cp "out/${APP_NAME}-linux-${{ matrix.arch }}" "desktop/tauri/src-tauri/bin/qbit-manage-linux-${{ matrix.arch }}"
+            chmod +x "desktop/tauri/src-tauri/bin/qbit-manage-linux-${{ matrix.arch }}"
+          fi
+
+      - name: Update Tauri version files
+        working-directory: desktop/tauri/src-tauri
+        shell: bash
+        run: |
+          # Run cargo check to trigger build script and update version files
+          cargo check
+
+      - name: Install Tauri CLI
+        working-directory: desktop/tauri/src-tauri
+        shell: bash
+        run: |
+          # Install Tauri 2 CLI (project migrated to Tauri v2 config & deps)
+          cargo install tauri-cli --version ^2 --locked --force
+
+      - name: Build Tauri app (initial attempt)
+        working-directory: desktop/tauri/src-tauri
+        shell: bash
+        run: |
+          # Build with explicit bundle targets for this platform
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cargo tauri build --target x86_64-pc-windows-msvc --bundles nsis
+          elif [[ "${{ runner.os }}" == "macOS" ]]; then
+            cargo tauri build --bundles app,dmg
+          else
+            cargo tauri build --bundles deb
+          fi
+        continue-on-error: true
+        id: tauri-build
+
+      - name: Wait before retry (macOS DMG recovery)
+        if: steps.tauri-build.outcome == 'failure' && runner.os == 'macOS'
+        run: sleep 30
+        shell: bash
+
+      - name: Wait before retry (build recovery)
+        if: steps.tauri-build.outcome == 'failure'
+        run: sleep 30
+        shell: bash
+
+      - name: Retry Tauri build on failure (attempt 2)
+        if: steps.tauri-build.outcome == 'failure'
+        working-directory: desktop/tauri/src-tauri
+        shell: bash
+        run: |
+          # Build with explicit bundle targets for this platform
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cargo tauri build --target x86_64-pc-windows-msvc --bundles nsis
+          elif [[ "${{ runner.os }}" == "macOS" ]]; then
+            cargo tauri build --bundles app,dmg
+          else
+            cargo tauri build --bundles deb
+          fi
+        continue-on-error: true
+        id: tauri-build-retry1
+
+      - name: Wait before final retry (build recovery)
+        if: steps.tauri-build-retry1.outcome == 'failure'
+        run: sleep 30
+        shell: bash
+
+      - name: Final retry Tauri build on failure (attempt 3)
+        if: steps.tauri-build-retry1.outcome == 'failure'
+        working-directory: desktop/tauri/src-tauri
+        shell: bash
+        run: |
+          # Build with explicit bundle targets for this platform
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cargo tauri build --target x86_64-pc-windows-msvc --bundles nsis
+          elif [[ "${{ runner.os }}" == "macOS" ]]; then
+            cargo tauri build --bundles app,dmg
+          else
+            cargo tauri build --bundles deb
+          fi
+
+      - name: Fail if all Tauri build attempts failed
+        if: steps.tauri-build.outcome == 'failure' && steps.tauri-build-retry1.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "❌ Tauri build failed after all attempts"
+          exit 1
+
+      - name: Set BUILD_ARCH for artifact naming
+        shell: bash
+        run: |
+          echo "BUILD_ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
+
+      - name: Upload build outputs (binary + Tauri bundles)
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-outputs-${{ runner.os }}-${{ env.BUILD_ARCH }}
+          path: |
+            out/**
+            desktop/tauri/src-tauri/target/**/release/bundle/**
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+
+  prepare-release-assets:
+    runs-on: ubuntu-latest
+    needs: build-binaries
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Download and collect all build outputs
+        uses: actions/download-artifact@v8
+        with:
+          pattern: build-outputs-*
+          path: collected
+          merge-multiple: true
+
+      - name: Filter and rename files for release
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+
+          echo "=== Collecting server binaries (standalone executables) ==="
+          # Copy server binaries with error checking
+          server_files=(
+            "qbit-manage-linux-amd64"
+            "qbit-manage-linux-arm64"
+            "qbit-manage-macos-arm64"
+            "qbit-manage-macos-x86_64"
+            "qbit-manage-windows-amd64.exe"
+          )
+
+          for server_file in "${server_files[@]}"; do
+            if find collected -name "$server_file" -exec cp {} release-assets/ \; -print | grep -q .; then
+              echo "✓ Found and copied: $server_file"
+            else
+              echo "⚠️  Warning: $server_file not found"
+            fi
+          done
+
+          echo "=== Processing installer files (desktop app packages) ==="
+
+          # Linux .deb installer
+          deb_count=$(find collected -name "*.deb" -exec cp {} release-assets/ \; -print | wc -l)
+          if [ "$deb_count" -gt 0 ]; then
+            echo "✓ Found $deb_count .deb installer(s)"
+            for file in release-assets/*.deb; do
+              if [ -f "$file" ]; then
+                basename=$(basename "$file" .deb)
+                mv "$file" "release-assets/${basename}-desktop-installer.deb"
+                echo "  → Renamed to: ${basename}-desktop-installer.deb"
+              fi
+            done
+          else
+            echo "⚠️  Warning: No .deb installers found"
+          fi
+
+          # macOS .dmg installers
+          dmg_count=$(find collected -name "*.dmg" -exec cp {} release-assets/ \; -print | wc -l)
+          if [ "$dmg_count" -gt 0 ]; then
+            echo "✓ Found $dmg_count .dmg installer(s)"
+            for file in release-assets/*.dmg; do
+              if [ -f "$file" ]; then
+                basename=$(basename "$file" .dmg)
+                mv "$file" "release-assets/${basename}-desktop-installer.dmg"
+                echo "  → Renamed to: ${basename}-desktop-installer.dmg"
+              fi
+            done
+          else
+            echo "⚠️  Warning: No .dmg installers found"
+          fi
+
+          # Windows .exe installer
+          exe_count=$(find collected -name "*-setup.exe" -exec cp {} release-assets/ \; -print | wc -l)
+          if [ "$exe_count" -gt 0 ]; then
+            echo "✓ Found $exe_count .exe installer(s)"
+            for file in release-assets/*-setup.exe; do
+              if [ -f "$file" ]; then
+                basename=$(basename "$file" -setup.exe)
+                mv "$file" "release-assets/${basename}-desktop-installer-setup.exe"
+                echo "  → Renamed to: ${basename}-desktop-installer-setup.exe"
+              fi
+            done
+          else
+            echo "⚠️  Warning: No .exe installers found"
+          fi
+
+          echo "=== File processing completed ==="
+
+      - name: Display final release assets
+        run: |
+          echo "=== Final Release Assets ==="
+          ls -la release-assets/
+          echo ""
+          echo "=== File Count Summary ==="
+          echo "Server binaries: $(find release-assets -name "qbit-manage-*" -not -name "*desktop*" | wc -l)"
+          echo "Desktop installers: $(find release-assets -name "*desktop-installer*" | wc -l)"
+
+      - name: Upload final release assets
+        uses: actions/upload-artifact@v7
+        with:
+          name: qbit-manage-release-assets
+          path: release-assets/*
+          if-no-files-found: error
+          compression-level: 6
+
+      - name: Clean up temporary build artifacts
+        uses: actions/github-script@v9
+        with:
+          script: |
+            // Get all artifacts from this workflow run
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+
+            // Delete temporary build artifacts, keep only the final release assets
+            for (const artifact of artifacts.data.artifacts) {
+              if (artifact.name.startsWith('build-outputs-')) {
+                console.log(`Deleting temporary artifact: ${artifact.name}`);
+                try {
+                  await github.rest.actions.deleteArtifact({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    artifact_id: artifact.id,
+                  });
+                  console.log(`✓ Successfully deleted: ${artifact.name}`);
+                } catch (error) {
+                  console.log(`⚠️  Failed to delete ${artifact.name}: ${error.message}`);
+                }
+              } else {
+                console.log(`✓ Keeping final artifact: ${artifact.name}`);
+              }
+            }

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -117,7 +117,6 @@ jobs:
             mv "dist/${APP_NAME}" "out/${APP_NAME}-linux-${{ matrix.arch }}"
           fi
 
-      # Build Tauri desktop shell after binaries are ready
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -147,6 +146,8 @@ jobs:
         with:
           workspaces: |
             desktop/tauri/src-tauri -> desktop/tauri/src-tauri/target
+          # Cache ~/.cargo/bin so the compiled tauri-cli is reused across runs.
+          cache-directories: ~/.cargo/bin
 
       - name: Install NSIS (Windows)
         if: runner.os == 'Windows'
@@ -168,7 +169,6 @@ jobs:
         run: |
           mkdir -p desktop/tauri/src-tauri/bin
 
-          # Copy the actual binary for this platform as a resource
           if [[ "${{ runner.os }}" == "Windows" ]]; then
             cp "out/${APP_NAME}-windows-${{ matrix.arch }}.exe" "desktop/tauri/src-tauri/bin/qbit-manage-windows-${{ matrix.arch }}.exe"
           elif [[ "${{ runner.os }}" == "macOS" ]]; then
@@ -183,21 +183,24 @@ jobs:
         working-directory: desktop/tauri/src-tauri
         shell: bash
         run: |
-          # Run cargo check to trigger build script and update version files
+          # cargo check runs the build script for its side effect (version files),
+          # not to type-check.
           cargo check
 
       - name: Install Tauri CLI
         working-directory: desktop/tauri/src-tauri
         shell: bash
         run: |
-          # Install Tauri 2 CLI (project migrated to Tauri v2 config & deps)
-          cargo install tauri-cli --version ^2 --locked --force
+          # Project is on Tauri v2; skip the (slow) source build when a cached v2
+          # CLI is already present.
+          if ! cargo tauri --version 2>/dev/null | grep -qE '^tauri-cli 2\.'; then
+            cargo install tauri-cli --version ^2 --locked
+          fi
 
       - name: Build Tauri app (initial attempt)
         working-directory: desktop/tauri/src-tauri
         shell: bash
         run: |
-          # Build with explicit bundle targets for this platform
           if [[ "${{ runner.os }}" == "Windows" ]]; then
             cargo tauri build --target x86_64-pc-windows-msvc --bundles nsis
           elif [[ "${{ runner.os }}" == "macOS" ]]; then
@@ -208,12 +211,7 @@ jobs:
         continue-on-error: true
         id: tauri-build
 
-      - name: Wait before retry (macOS DMG recovery)
-        if: steps.tauri-build.outcome == 'failure' && runner.os == 'macOS'
-        run: sleep 30
-        shell: bash
-
-      - name: Wait before retry (build recovery)
+      - name: Wait before retry
         if: steps.tauri-build.outcome == 'failure'
         run: sleep 30
         shell: bash
@@ -223,7 +221,6 @@ jobs:
         working-directory: desktop/tauri/src-tauri
         shell: bash
         run: |
-          # Build with explicit bundle targets for this platform
           if [[ "${{ runner.os }}" == "Windows" ]]; then
             cargo tauri build --target x86_64-pc-windows-msvc --bundles nsis
           elif [[ "${{ runner.os }}" == "macOS" ]]; then
@@ -243,8 +240,9 @@ jobs:
         if: steps.tauri-build-retry1.outcome == 'failure'
         working-directory: desktop/tauri/src-tauri
         shell: bash
+        continue-on-error: true
+        id: tauri-build-retry2
         run: |
-          # Build with explicit bundle targets for this platform
           if [[ "${{ runner.os }}" == "Windows" ]]; then
             cargo tauri build --target x86_64-pc-windows-msvc --bundles nsis
           elif [[ "${{ runner.os }}" == "macOS" ]]; then
@@ -253,8 +251,13 @@ jobs:
             cargo tauri build --bundles deb
           fi
 
+      # Fail only when the LAST attempt that ran failed — checking the first two
+      # outcomes alone would falsely fail a build that recovered on attempt 3.
       - name: Fail if all Tauri build attempts failed
-        if: steps.tauri-build.outcome == 'failure' && steps.tauri-build-retry1.outcome == 'failure'
+        if: >-
+          steps.tauri-build.outcome == 'failure' &&
+          steps.tauri-build-retry1.outcome == 'failure' &&
+          steps.tauri-build-retry2.outcome == 'failure'
         shell: bash
         run: |
           echo "❌ Tauri build failed after all attempts"
@@ -274,7 +277,7 @@ jobs:
             desktop/tauri/src-tauri/target/**/release/bundle/**
           if-no-files-found: error
           retention-days: 7
-          compression-level: 0
+          compression-level: 6
 
   prepare-release-assets:
     runs-on: ubuntu-latest
@@ -384,14 +387,12 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            // Get all artifacts from this workflow run
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: context.runId,
             });
 
-            // Delete temporary build artifacts, keep only the final release assets
             for (const artifact of artifacts.data.artifacts) {
               if (artifact.name.startsWith('build-outputs-')) {
                 console.log(`Deleting temporary artifact: ${artifact.name}`);

--- a/.github/workflows/bump-version-develop.yml
+++ b/.github/workflows/bump-version-develop.yml
@@ -68,5 +68,5 @@ jobs:
           git config user.name 'qbit-manage-bot'
           git config user.email 'qbit-manage-bot@users.noreply.github.com'
           git add VERSION
-          git commit -m "chore: bump VERSION to ${{ steps.bump.outputs.after }} [skip-version-bump]"
+          git commit -m "chore: bump VERSION to ${{ steps.bump.outputs.after }} [skip-version-bump][skip ci]"
           git push origin develop

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -24,15 +24,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  actions: write
-
 jobs:
   build-release-assets:
     name: Build develop assets
     # Upstream-only: forks shouldn't burn ~5 OS-runners on every develop push.
     if: github.repository == 'StuffAnThings/qbit_manage'
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/build-binaries.yml
     with:
       ref: ${{ github.sha }}
@@ -70,7 +69,11 @@ jobs:
           # This keeps a single, always-current develop pre-release instead of one
           # per merge. The tag is intentionally non-`v*` so it never trips
           # tag.yml / version.yml / pypi-publish.yml.
-          gh release delete "$TAG" --cleanup-tag --yes || true
+          # Delete only when it exists, so a real auth/permission error surfaces
+          # instead of being masked by `|| true`.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release delete "$TAG" --cleanup-tag --yes
+          fi
           gh release create "$TAG" \
             --target "${{ github.sha }}" \
             --title "Develop build ($VERSION)" \
@@ -83,6 +86,8 @@ jobs:
     runs-on: ubuntu-latest
     # Upstream-only: DOCKER_HUB_USERNAME / GHCR_TOKEN aren't configured on forks.
     if: github.repository == 'StuffAnThings/qbit_manage'
+    permissions:
+      contents: read
 
     steps:
       - name: set lower case owner name
@@ -94,7 +99,7 @@ jobs:
       - name: Check Out Repo
         uses: actions/checkout@v7
         with:
-          ref: develop
+          ref: ${{ github.sha }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,4 +1,6 @@
-# Builds binaries and Docker image for the develop branch on every push or manual trigger.
+# On every push to develop: build the binary + Tauri matrix (reusable workflow),
+# refresh the rolling `latest-develop` pre-release with those assets, and push the
+# `:develop` Docker image.
 name: Docker Develop Release
 
 on:
@@ -22,373 +24,60 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  actions: write
+
 jobs:
-  build-binaries:
-    name: Build Standalone Binaries (${{ matrix.os }})
+  build-release-assets:
+    name: Build develop assets
     # Upstream-only: forks shouldn't burn ~5 OS-runners on every develop push.
     if: github.repository == 'StuffAnThings/qbit_manage'
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      ref: ${{ github.sha }}
+
+  develop-prerelease:
+    name: Update rolling develop pre-release
+    needs: build-release-assets
+    # Upstream-only: rolling pre-release lives on the upstream repo.
+    if: github.repository == 'StuffAnThings/qbit_manage'
+    runs-on: ubuntu-latest
     permissions:
-      contents: read
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            python-version: "3.14"
-            arch: amd64
-          - os: ubuntu-24.04-arm # for Arm based Linux (Raspberry Pi, etc.)
-            python-version: "3.14"
-            arch: arm64
-          - os: windows-latest
-            python-version: "3.14"
-            arch: amd64
-          - os: "macos-latest" # for Arm based macs (M1 and above).
-            python-version: "3.14"
-            arch: arm64
-          - os: "macos-15-intel" # for Intel based macs.
-            python-version: "3.14"
-            arch: x86_64
-    env:
-      APP_NAME: qbit-manage
-      ENTRY: qbit_manage.py
+      contents: write
     steps:
-      - name: Check Out Repo
+      - name: Check Out develop commit
         uses: actions/checkout@v7
         with:
-          ref: develop
+          ref: ${{ github.sha }}
 
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: |
-            pyproject.toml
-            uv.lock
-
-      - name: Upgrade Pip and install project + PyInstaller
-        run: |
-          python -m pip install --upgrade pip wheel
-          python -m pip install . pyinstaller
-
-      - name: Compute add-data separator
-        id: sep
-        shell: bash
-        run: |
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            echo "SEP=;" >> $GITHUB_OUTPUT
-          else
-            echo "SEP=:" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Build (PyInstaller onefile)
-        shell: bash
-        run: |
-          ADD_WEBUI="web-ui${{ steps.sep.outputs.SEP }}web-ui"
-          ADD_SAMPLE_CFG="config/config.yml.sample${{ steps.sep.outputs.SEP }}config"
-          ADD_LOGO="icons/qbm_logo.png${{ steps.sep.outputs.SEP }}."
-          ADD_VERSION="VERSION${{ steps.sep.outputs.SEP }}."
-          ADD_DOCS="docs${{ steps.sep.outputs.SEP }}docs"
-          ICON_ARG=""
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            ICON_ARG=--icon=icons/qbm_logo.ico
-          elif [[ "${{ runner.os }}" == "macOS" ]]; then
-            ICON_ARG=--icon=icons/qbm_logo.icns
-          else
-            # Linux: optional icon (helps some desktop environments)
-            if [[ -f icons/qbm_logo.png ]]; then
-              ICON_ARG=--icon=icons/qbm_logo.png
-            elif [[ -f icons/qbm_logo.ico ]]; then
-              ICON_ARG=--icon=icons/qbm_logo.ico
-            fi
-          fi
-          pyinstaller --noconfirm \
-                      --clean \
-                      --onefile \
-                      --name "${APP_NAME}" \
-                      --add-data "$ADD_WEBUI" \
-                      --add-data "$ADD_SAMPLE_CFG" \
-                      --add-data "$ADD_LOGO" \
-                      --add-data "$ADD_VERSION" \
-                      --add-data "$ADD_DOCS" \
-                      $ICON_ARG \
-                      "${ENTRY}"
-
-      - name: Rename output for OS
-        shell: bash
-        run: |
-          mkdir -p out
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            mv "dist/${APP_NAME}.exe" "out/${APP_NAME}-windows-${{ matrix.arch }}.exe"
-          elif [[ "${{ runner.os }}" == "macOS" ]]; then
-            mv "dist/${APP_NAME}" "out/${APP_NAME}-macos-${{ matrix.arch }}"
-          else
-            mv "dist/${APP_NAME}" "out/${APP_NAME}-linux-${{ matrix.arch }}"
-          fi
-
-      # Build Tauri desktop shell after binaries are ready
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-        env:
-          RUSTUP_MAX_RETRIES: 10
-        timeout-minutes: 10
-        continue-on-error: true
-        id: rust-setup
-
-      - name: Wait before retry (network recovery)
-        if: steps.rust-setup.outcome == 'failure'
-        run: sleep 30
-        shell: bash
-
-      - name: Retry Rust toolchain setup on failure
-        if: steps.rust-setup.outcome == 'failure'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-        env:
-          RUSTUP_MAX_RETRIES: 10
-        timeout-minutes: 10
-
-      - name: Rust cache
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            desktop/tauri/src-tauri -> desktop/tauri/src-tauri/target
-
-      - name: Install NSIS (Windows)
-        if: runner.os == 'Windows'
-        shell: powershell
-        run: choco install nsis -y
-
-      - name: Install Tauri dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          # Ubuntu 24.04 (noble) uses libwebkit2gtk-4.1-dev (4.0 no longer available)
-          # Install core deps first
-          sudo apt-get install -y libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf
-          # Try new package name, fall back for older runners
-          sudo apt-get install -y libwebkit2gtk-4.1-dev || sudo apt-get install -y libwebkit2gtk-4.0-dev
-
-      - name: Prepare Tauri server binary
-        shell: bash
-        run: |
-          mkdir -p desktop/tauri/src-tauri/bin
-
-          # Copy the actual binary for this platform as a resource
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cp "out/${APP_NAME}-windows-${{ matrix.arch }}.exe" "desktop/tauri/src-tauri/bin/qbit-manage-windows-${{ matrix.arch }}.exe"
-          elif [[ "${{ runner.os }}" == "macOS" ]]; then
-            cp "out/${APP_NAME}-macos-${{ matrix.arch }}" "desktop/tauri/src-tauri/bin/qbit-manage-macos-${{ matrix.arch }}"
-            chmod +x "desktop/tauri/src-tauri/bin/qbit-manage-macos-${{ matrix.arch }}"
-          else
-            cp "out/${APP_NAME}-linux-${{ matrix.arch }}" "desktop/tauri/src-tauri/bin/qbit-manage-linux-${{ matrix.arch }}"
-            chmod +x "desktop/tauri/src-tauri/bin/qbit-manage-linux-${{ matrix.arch }}"
-          fi
-
-      - name: Update Tauri version files
-        working-directory: desktop/tauri/src-tauri
-        shell: bash
-        run: |
-          # Run cargo check to trigger build script and update version files
-          cargo check
-
-      - name: Install Tauri CLI
-        working-directory: desktop/tauri/src-tauri
-        shell: bash
-        run: |
-          # Install Tauri 2 CLI (project migrated to Tauri v2 config & deps)
-          cargo install tauri-cli --version ^2 --locked --force
-
-      - name: Build Tauri app (initial attempt)
-        working-directory: desktop/tauri/src-tauri
-        shell: bash
-        run: |
-          # Build with explicit bundle targets for this platform
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cargo tauri build --target x86_64-pc-windows-msvc --bundles nsis
-          elif [[ "${{ runner.os }}" == "macOS" ]]; then
-            cargo tauri build --bundles app,dmg
-          else
-            cargo tauri build --bundles deb
-          fi
-        continue-on-error: true
-        id: tauri-build
-
-      - name: Wait before retry (macOS DMG recovery)
-        if: steps.tauri-build.outcome == 'failure' && runner.os == 'macOS'
-        run: sleep 30
-        shell: bash
-
-      - name: Wait before retry (build recovery)
-        if: steps.tauri-build.outcome == 'failure'
-        run: sleep 30
-        shell: bash
-
-      - name: Retry Tauri build on failure (attempt 2)
-        if: steps.tauri-build.outcome == 'failure'
-        working-directory: desktop/tauri/src-tauri
-        shell: bash
-        run: |
-          # Build with explicit bundle targets for this platform
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cargo tauri build --target x86_64-pc-windows-msvc --bundles nsis
-          elif [[ "${{ runner.os }}" == "macOS" ]]; then
-            cargo tauri build --bundles app,dmg
-          else
-            cargo tauri build --bundles deb
-          fi
-        continue-on-error: true
-        id: tauri-build-retry1
-
-      - name: Wait before final retry (build recovery)
-        if: steps.tauri-build-retry1.outcome == 'failure'
-        run: sleep 30
-        shell: bash
-
-      - name: Final retry Tauri build on failure (attempt 3)
-        if: steps.tauri-build-retry1.outcome == 'failure'
-        working-directory: desktop/tauri/src-tauri
-        shell: bash
-        run: |
-          # Build with explicit bundle targets for this platform
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cargo tauri build --target x86_64-pc-windows-msvc --bundles nsis
-          elif [[ "${{ runner.os }}" == "macOS" ]]; then
-            cargo tauri build --bundles app,dmg
-          else
-            cargo tauri build --bundles deb
-          fi
-
-      - name: Fail if all Tauri build attempts failed
-        if: steps.tauri-build.outcome == 'failure' && steps.tauri-build-retry1.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "❌ Tauri build failed after all attempts"
-          exit 1
-
-      - name: Set BUILD_ARCH for artifact naming
-        shell: bash
-        run: |
-          echo "BUILD_ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-
-      - name: Upload build outputs (binary + Tauri bundles)
-        uses: actions/upload-artifact@v7
-        with:
-          name: build-outputs-${{ runner.os }}-${{ env.BUILD_ARCH }}
-          path: |
-            out/**
-            desktop/tauri/src-tauri/target/**/release/bundle/**
-          if-no-files-found: error
-          retention-days: 7
-          compression-level: 0
-
-  prepare-release-assets:
-    runs-on: ubuntu-latest
-    needs: build-binaries
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - name: Download and collect all build outputs
+      - name: Download prepared release assets
         uses: actions/download-artifact@v8
         with:
-          pattern: build-outputs-*
-          path: collected
-          merge-multiple: true
+          name: qbit-manage-release-assets
+          path: release-assets
 
-      - name: Filter and rename files for release
-        shell: bash
+      - name: Recreate rolling pre-release at current develop HEAD
+        env:
+          GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          mkdir -p release-assets
+          VERSION="$(cat VERSION)"
+          TAG="latest-develop"
 
-          echo "=== Collecting server binaries (standalone executables) ==="
-          # Copy server binaries with error checking
-          server_files=(
-            "qbit-manage-linux-amd64"
-            "qbit-manage-linux-arm64"
-            "qbit-manage-macos-arm64"
-            "qbit-manage-macos-x86_64"
-            "qbit-manage-windows-amd64.exe"
-          )
-
-          for server_file in "${server_files[@]}"; do
-            if find collected -name "$server_file" -exec cp {} release-assets/ \; -print | grep -q .; then
-              echo "✓ Found and copied: $server_file"
-            else
-              echo "⚠️  Warning: $server_file not found"
-            fi
-          done
-
-          echo "=== Processing installer files (desktop app packages) ==="
-
-          # Linux .deb installer
-          deb_count=$(find collected -name "*.deb" -exec cp {} release-assets/ \; -print | wc -l)
-          if [ "$deb_count" -gt 0 ]; then
-            echo "✓ Found $deb_count .deb installer(s)"
-            for file in release-assets/*.deb; do
-              if [ -f "$file" ]; then
-                basename=$(basename "$file" .deb)
-                mv "$file" "release-assets/${basename}-desktop-installer.deb"
-                echo "  → Renamed to: ${basename}-desktop-installer.deb"
-              fi
-            done
-          else
-            echo "⚠️  Warning: No .deb installers found"
-          fi
-
-          # macOS .dmg installers
-          dmg_count=$(find collected -name "*.dmg" -exec cp {} release-assets/ \; -print | wc -l)
-          if [ "$dmg_count" -gt 0 ]; then
-            echo "✓ Found $dmg_count .dmg installer(s)"
-            for file in release-assets/*.dmg; do
-              if [ -f "$file" ]; then
-                basename=$(basename "$file" .dmg)
-                mv "$file" "release-assets/${basename}-desktop-installer.dmg"
-                echo "  → Renamed to: ${basename}-desktop-installer.dmg"
-              fi
-            done
-          else
-            echo "⚠️  Warning: No .dmg installers found"
-          fi
-
-          # Windows .exe installer
-          exe_count=$(find collected -name "*-setup.exe" -exec cp {} release-assets/ \; -print | wc -l)
-          if [ "$exe_count" -gt 0 ]; then
-            echo "✓ Found $exe_count .exe installer(s)"
-            for file in release-assets/*-setup.exe; do
-              if [ -f "$file" ]; then
-                basename=$(basename "$file" -setup.exe)
-                mv "$file" "release-assets/${basename}-desktop-installer-setup.exe"
-                echo "  → Renamed to: ${basename}-desktop-installer-setup.exe"
-              fi
-            done
-          else
-            echo "⚠️  Warning: No .exe installers found"
-          fi
-
-          echo "=== File processing completed ==="
-
-      - name: Display final release assets
-        run: |
-          echo "=== Final Release Assets ==="
-          ls -la release-assets/
-          echo ""
-          echo "=== File Count Summary ==="
-          echo "Server binaries: $(find release-assets -name "qbit-manage-*" -not -name "*desktop*" | wc -l)"
-          echo "Desktop installers: $(find release-assets -name "*desktop-installer*" | wc -l)"
-
-      - name: Upload final release assets
-        uses: actions/upload-artifact@v7
-        with:
-          name: qbit-manage-release-assets
-          path: release-assets/*
-          if-no-files-found: error
-          compression-level: 6
+          # The GitHub API cannot move an existing tag to a new commit, so delete
+          # the rolling release + its tag and recreate both at the current HEAD.
+          # This keeps a single, always-current develop pre-release instead of one
+          # per merge. The tag is intentionally non-`v*` so it never trips
+          # tag.yml / version.yml / pypi-publish.yml.
+          gh release delete "$TAG" --cleanup-tag --yes || true
+          gh release create "$TAG" \
+            --target "${{ github.sha }}" \
+            --title "Develop build ($VERSION)" \
+            --notes "Rolling pre-release built from the latest \`develop\` commit (\`${{ github.sha }}\`). Auto-updated on every merge to develop — this is a development build, not a stable release." \
+            --prerelease \
+            --latest=false \
+            release-assets/*
 
   docker-develop:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,31 @@
+# Builds the full binary + desktop matrix for a PR ONLY when a maintainer adds the
+# `build` label, so reviewers can download + test the artifacts before merge.
+# Default (unlabeled) PRs cost zero runner minutes here.
+name: PR Build Artifacts
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  # Cancel a superseded build when a new commit lands on the same PR.
+  group: pr-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  build-pr-assets:
+    name: Build PR test assets
+    # Two gates: (1) only on the upstream repo — a fork's own PRs never burn the
+    # fork owner's minutes here; (2) only when the maintainer-only `build` label
+    # is present. Together these mean a fork PR builds only after a maintainer
+    # opts it in on upstream.
+    if: >-
+      github.repository == 'StuffAnThings/qbit_manage' &&
+      contains(github.event.pull_request.labels.*.name, 'build')
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,15 +1,15 @@
-# Builds the full binary + desktop matrix for a PR ONLY when a maintainer adds the
-# `build` label, so reviewers can download + test the artifacts before merge.
-# Default (unlabeled) PRs cost zero runner minutes here.
+# PR build artifacts + a pr-<number> docker image so reviewers can test before merge.
+#
+# Repo owner + org members build automatically on every push. Everyone else
+# (outside collaborators, contributors, fork PRs) builds only when a maintainer
+# adds the `build` label — and only on that labeled event (a later push does NOT
+# rebuild under the still-present label; re-add the label to rebuild).
+# Other PRs cost zero runner minutes here.
 name: PR Build Artifacts
 
 on:
   pull_request:
-    # `labeled` ONLY (not synchronize): a build is tied to the exact commit a
-    # maintainer reviewed when they added the label. A later push does NOT
-    # rebuild with the still-present label (TOCTOU) — re-add the label to
-    # rebuild against the new HEAD.
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: pr-build-${{ github.event.pull_request.number }}
@@ -22,13 +22,68 @@ permissions:
 jobs:
   build-pr-assets:
     name: Build PR test assets
-    # Two gates: (1) only on the upstream repo — a fork's own PRs never burn the
-    # fork owner's minutes here; (2) only when the maintainer-only `build` label
-    # is present. Together these mean a fork PR builds only after a maintainer
-    # opts it in on upstream.
     if: >-
-      github.repository == 'StuffAnThings/qbit_manage' &&
-      contains(github.event.pull_request.labels.*.name, 'build')
+      github.repository == 'StuffAnThings/qbit_manage' && (
+        contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)
+        || (github.event.action == 'labeled' && github.event.label.name == 'build')
+      )
     uses: ./.github/workflows/build-binaries.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
+
+  docker-pr:
+    name: Build PR docker image (pr-N)
+    # Additionally requires a same-repo head: pushing to GHCR needs packages:write
+    # + secrets, which a fork PR's read-only token doesn't have. Fork PRs still get
+    # the binary artifacts from build-pr-assets above.
+    if: >-
+      github.repository == 'StuffAnThings/qbit_manage' &&
+      github.event.pull_request.head.repo.full_name == github.repository && (
+        contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)
+        || (github.event.action == 'labeled' && github.event.label.name == 'build')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: set lower case owner name
+        run: echo "OWNER_LC=${OWNER,,}" >>"${GITHUB_ENV}"
+        env:
+          OWNER: "${{ github.repository_owner }}"
+
+      - name: Check Out PR head
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ env.OWNER_LC }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Read version from VERSION file
+        id: get_version
+        run: echo "APP_VERSION=$(cat VERSION)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push pr-${{ github.event.pull_request.number }}
+        uses: docker/build-push-action@v7
+        with:
+          context: ./
+          file: ./Dockerfile
+          build-args: |
+            APP_VERSION=${{ steps.get_version.outputs.APP_VERSION }}
+          # amd64 only: PR preview images favor speed over multi-arch coverage.
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ env.OWNER_LC }}/qbit_manage:pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -5,10 +5,13 @@ name: PR Build Artifacts
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    # `labeled` ONLY (not synchronize): a build is tied to the exact commit a
+    # maintainer reviewed when they added the label. A later push does NOT
+    # rebuild with the still-present label (TOCTOU) — re-add the label to
+    # rebuild against the new HEAD.
+    types: [labeled]
 
 concurrency:
-  # Cancel a superseded build when a new commit lands on the same PR.
   group: pr-build-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -143,6 +143,7 @@ jobs:
     needs: prepare-release-branch
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.repository == 'StuffAnThings/qbit_manage'
 
     steps:
       - name: Check Out release branch
@@ -157,15 +158,19 @@ jobs:
 
       - name: Generate release notes from git log
         id: notes
+        env:
+          # Via env, never interpolated into the script body — prevents shell
+          # injection from a maliciously crafted dispatch input.
+          RELEASE_NOTES_OVERRIDE: ${{ inputs.release_notes_override }}
+          NEW_VERSION: ${{ needs.prepare-release-branch.outputs.new_version }}
         run: |
-          NEW_VERSION="${{ needs.prepare-release-branch.outputs.new_version }}"
-          OVERRIDE="${{ inputs.release_notes_override }}"
+          OVERRIDE="${RELEASE_NOTES_OVERRIDE}"
 
           if [[ -n "$OVERRIDE" ]]; then
             NOTES="$OVERRIDE"
           else
-            # Commits on this release branch that are NOT yet on master
-            LOG=$(git log origin/master..HEAD --oneline --no-merges 2>/dev/null || echo "")
+            # Exclude the pipeline's own VERSION-bump commit from the notes.
+            LOG=$(git log origin/master..HEAD --oneline --no-merges 2>/dev/null | grep -v 'chore(release): bump VERSION' || true)
 
             if [[ -z "$LOG" ]]; then
               NOTES="No new commits since last release."
@@ -194,7 +199,6 @@ jobs:
             fi
           fi
 
-          # Footer reminder about branch cleanup
           NOTES+=$'\n'"---"$'\n'
           NOTES+="_This PR was opened by the **Release PR** workflow. The \`${{ needs.prepare-release-branch.outputs.release_branch }}\` branch will auto-delete on merge (repo setting \"Automatically delete head branches\")._"$'\n'
 
@@ -202,13 +206,11 @@ jobs:
           echo "Notes written."
 
       - name: Open PR ${{ needs.prepare-release-branch.outputs.release_branch }} → master
-        id: open-pr
         env:
           GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ needs.prepare-release-branch.outputs.release_branch }}
+          NEW_VERSION: ${{ needs.prepare-release-branch.outputs.new_version }}
         run: |
-          BRANCH="${{ needs.prepare-release-branch.outputs.release_branch }}"
-          NEW_VERSION="${{ needs.prepare-release-branch.outputs.new_version }}"
-
           PR_URL=$(gh pr create \
             --base master \
             --head "$BRANCH" \
@@ -217,7 +219,6 @@ jobs:
             --label release)
 
           echo "Release PR: $PR_URL"
-          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Job 3: Build release assets off the release branch (reusable matrix)
@@ -240,6 +241,7 @@ jobs:
     needs: [prepare-release-branch, build-release-assets]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.repository == 'StuffAnThings/qbit_manage'
 
     steps:
       - name: Check Out release branch
@@ -249,19 +251,35 @@ jobs:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
+      - name: Resolve release commit SHA
+        id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse to overwrite an already-published release
+        env:
+          GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          TAG: "v${{ needs.prepare-release-branch.outputs.new_version }}"
+        run: |
+          if gh release view "$TAG" --json isDraft -q '.isDraft' 2>/dev/null | grep -qx 'false'; then
+            echo "::error::Release $TAG already exists and is published. Delete it before re-running."
+            exit 1
+          fi
+
       - name: Fetch master for changelog range
         run: git fetch origin master
 
       - name: Regenerate release notes for GitHub release
         id: notes
+        env:
+          RELEASE_NOTES_OVERRIDE: ${{ inputs.release_notes_override }}
+          NEW_VERSION: ${{ needs.prepare-release-branch.outputs.new_version }}
         run: |
-          NEW_VERSION="${{ needs.prepare-release-branch.outputs.new_version }}"
-          OVERRIDE="${{ inputs.release_notes_override }}"
+          OVERRIDE="${RELEASE_NOTES_OVERRIDE}"
 
           if [[ -n "$OVERRIDE" ]]; then
             NOTES="$OVERRIDE"
           else
-            LOG=$(git log origin/master..HEAD --oneline --no-merges 2>/dev/null || echo "")
+            LOG=$(git log origin/master..HEAD --oneline --no-merges 2>/dev/null | grep -v 'chore(release): bump VERSION' || true)
 
             if [[ -z "$LOG" ]]; then
               NOTES="No new commits since last release."
@@ -319,5 +337,7 @@ jobs:
           draft: true
           prerelease: false
           allowUpdates: true
-          commit: ${{ needs.prepare-release-branch.outputs.release_branch }}
+          # SHA, not the branch name — the release branch is deleted on merge,
+          # which would leave the release with a dangling target_commitish.
+          commit: ${{ steps.sha.outputs.sha }}
           skipIfReleaseExists: false

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,10 +1,14 @@
-# Manually triggered: creates a release branch from develop, opens a PR to master, and drafts a GitHub release.
+# Manually triggered: creates a release branch from develop, opens a PR to master,
+# builds the standalone binaries / desktop bundles, and creates a draft GitHub
+# release with those assets attached so they can be tested before the PR merges.
 name: Release PR
 
-# Creates a release branch (copy of develop), opens a PR to master, and
-# creates a draft GitHub release. Operator reviews the PR, then merges
-# normally — existing tag.yml + pypi-publish.yml + version.yml +
-# update-develop-branch.yml workflows take over from there.
+# Creates a release branch (copy of develop), opens a PR to master, builds the
+# release assets off that branch (via the reusable build-binaries workflow), and
+# creates a draft GitHub release with the assets + auto-generated notes attached.
+# Operator reviews the PR (and can test the attached binaries), then merges
+# normally — tag.yml pushes the tag and version.yml publishes this draft + pushes
+# the Docker image.
 #
 # IMPORTANT: enable "Automatically delete head branches" in the repo's
 # Settings → General → Pull Requests so the release/vX.Y.Z branch is
@@ -34,6 +38,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────────
@@ -215,11 +220,24 @@ jobs:
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
 
   # ─────────────────────────────────────────────────────────────────────────────
-  # Job 3: Create a draft GitHub release (tag not pushed yet)
+  # Job 3: Build release assets off the release branch (reusable matrix)
+  # ─────────────────────────────────────────────────────────────────────────────
+  build-release-assets:
+    name: Build release assets
+    needs: prepare-release-branch
+    # Upstream-only (defense in depth; prepare-release-branch is already gated).
+    if: github.repository == 'StuffAnThings/qbit_manage'
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      ref: ${{ needs.prepare-release-branch.outputs.release_branch }}
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 4: Create a draft GitHub release with the built assets attached
+  #        (tag ref not pushed yet — that happens post-merge via tag.yml)
   # ─────────────────────────────────────────────────────────────────────────────
   create-draft-release:
     name: Create draft GitHub release
-    needs: [prepare-release-branch, open-release-pr]
+    needs: [prepare-release-branch, build-release-assets]
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -274,14 +292,21 @@ jobs:
 
           printf '%s' "$NOTES" > /tmp/draft_release_notes.md
 
-      - name: Create draft GitHub release (no tag yet)
+      - name: Download prepared release assets
+        uses: actions/download-artifact@v8
+        with:
+          name: qbit-manage-release-assets
+          path: release-assets
+
+      - name: Create draft GitHub release with assets (no tag yet)
         # Switched from softprops/action-gh-release to ncipollo/release-action
         # because softprops creates the tag ref immediately on `draft: true`,
         # which triggers tag-watching workflows (pypi-publish.yml /
         # version.yml) before the release PR is reviewed + merged.
         # ncipollo records the tag in the release object but does NOT push
         # the underlying tag ref while the release stays in draft. The
-        # tag is created post-merge by tag.yml when master advances.
+        # tag is created post-merge by tag.yml when master advances, and
+        # version.yml then flips this draft to published.
         # (Copilot review #1200 + operator pick 2026-05-22.)
         uses: ncipollo/release-action@v1
         with:
@@ -289,6 +314,8 @@ jobs:
           tag: "v${{ needs.prepare-release-branch.outputs.new_version }}"
           name: "v${{ needs.prepare-release-branch.outputs.new_version }}"
           bodyFile: /tmp/draft_release_notes.md
+          artifacts: "release-assets/*"
+          artifactErrorsFailBuild: true
           draft: true
           prerelease: false
           allowUpdates: true

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -87,8 +87,10 @@ jobs:
     name: Publish draft release from Release PR
     runs-on: ubuntu-latest
     needs: [docker-release]
+    # always(): publishing the release must not be blocked by a transient Docker
+    # push failure — the draft + its assets are independent of the image.
     # Upstream-only: the draft release + PAT live on the upstream repo.
-    if: github.repository == 'StuffAnThings/qbit_manage'
+    if: always() && github.repository == 'StuffAnThings/qbit_manage'
     permissions:
       contents: write
     steps:
@@ -98,7 +100,7 @@ jobs:
 
       - name: Publish the draft release (keep its notes + assets)
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           TAG="${{ steps.get_version.outputs.VERSION }}"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,4 +1,7 @@
-# Builds binaries, Docker image, and creates the GitHub release on every version tag push.
+# On every version tag push: build + push the Docker image, then publish the draft
+# GitHub release that release-pr.yml already prepared (binaries + auto-generated
+# notes attached to the draft). No rebuild, no CHANGELOG — the draft is the source
+# of truth; this workflow only flips it from draft to published.
 name: Version Release
 
 on:
@@ -11,401 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-binaries:
-    name: Build Standalone Binaries (${{ matrix.os }})
-    # Upstream-only: forks shouldn't run the full release matrix on every tag.
-    if: github.repository == 'StuffAnThings/qbit_manage'
-    permissions:
-      contents: read
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            python-version: "3.14"
-            arch: amd64
-          - os: ubuntu-24.04-arm # for Arm based Linux (Raspberry Pi, etc.)
-            python-version: "3.14"
-            arch: arm64
-          - os: windows-latest
-            python-version: "3.14"
-            arch: amd64
-          - os: "macos-latest" # for Arm based macs (M1 and above).
-            python-version: "3.14"
-            arch: arm64
-          - os: "macos-15-intel" # for Intel based macs.
-            python-version: "3.14"
-            arch: x86_64
-    env:
-      APP_NAME: qbit-manage
-      ENTRY: qbit_manage.py
-    steps:
-      - name: Check Out Repo
-        uses: actions/checkout@v7
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: |
-            pyproject.toml
-            uv.lock
-
-      - name: Upgrade Pip and install project + PyInstaller
-        run: |
-          python -m pip install --upgrade pip wheel
-          python -m pip install . pyinstaller
-
-      - name: Compute add-data separator
-        id: sep
-        shell: bash
-        run: |
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            echo "SEP=;" >> $GITHUB_OUTPUT
-          else
-            echo "SEP=:" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Build (PyInstaller onefile)
-        shell: bash
-        run: |
-          ADD_WEBUI="web-ui${{ steps.sep.outputs.SEP }}web-ui"
-          ADD_SAMPLE_CFG="config/config.yml.sample${{ steps.sep.outputs.SEP }}config"
-          ADD_LOGO="icons/qbm_logo.png${{ steps.sep.outputs.SEP }}."
-          ADD_VERSION="VERSION${{ steps.sep.outputs.SEP }}."
-          ADD_DOCS="docs${{ steps.sep.outputs.SEP }}docs"
-          ICON_ARG=""
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            ICON_ARG=--icon=icons/qbm_logo.ico
-          elif [[ "${{ runner.os }}" == "macOS" ]]; then
-            ICON_ARG=--icon=icons/qbm_logo.icns
-          else
-            # Linux: optional icon (helps some desktop environments)
-            if [[ -f icons/qbm_logo.png ]]; then
-              ICON_ARG=--icon=icons/qbm_logo.png
-            elif [[ -f icons/qbm_logo.ico ]]; then
-              ICON_ARG=--icon=icons/qbm_logo.ico
-            fi
-          fi
-          pyinstaller --noconfirm \
-                      --clean \
-                      --onefile \
-                      --name "${APP_NAME}" \
-                      --add-data "$ADD_WEBUI" \
-                      --add-data "$ADD_SAMPLE_CFG" \
-                      --add-data "$ADD_LOGO" \
-                      --add-data "$ADD_VERSION" \
-                      --add-data "$ADD_DOCS" \
-                      $ICON_ARG \
-                      "${ENTRY}"
-
-      - name: Rename output for OS
-        shell: bash
-        run: |
-          mkdir -p out
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            mv "dist/${APP_NAME}.exe" "out/${APP_NAME}-windows-${{ matrix.arch }}.exe"
-          elif [[ "${{ runner.os }}" == "macOS" ]]; then
-            mv "dist/${APP_NAME}" "out/${APP_NAME}-macos-${{ matrix.arch }}"
-          else
-            mv "dist/${APP_NAME}" "out/${APP_NAME}-linux-${{ matrix.arch }}"
-          fi
-
-      # Build Tauri desktop shell after binaries are ready
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-        env:
-          RUSTUP_MAX_RETRIES: 10
-        timeout-minutes: 10
-        continue-on-error: true
-        id: rust-setup
-
-      - name: Wait before retry (network recovery)
-        if: steps.rust-setup.outcome == 'failure'
-        run: sleep 30
-        shell: bash
-
-      - name: Retry Rust toolchain setup on failure
-        if: steps.rust-setup.outcome == 'failure'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-        env:
-          RUSTUP_MAX_RETRIES: 10
-        timeout-minutes: 10
-
-      - name: Rust cache
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            desktop/tauri/src-tauri -> desktop/tauri/src-tauri/target
-
-      - name: Install NSIS (Windows)
-        if: runner.os == 'Windows'
-        shell: powershell
-        run: choco install nsis -y
-
-      - name: Install Tauri dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          # Ubuntu 24.04 (noble) uses libwebkit2gtk-4.1-dev (4.0 no longer available)
-          # Install core deps first
-          sudo apt-get install -y libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf
-          # Try new package name, fall back for older runners
-          sudo apt-get install -y libwebkit2gtk-4.1-dev || sudo apt-get install -y libwebkit2gtk-4.0-dev
-
-      - name: Prepare Tauri server binary
-        shell: bash
-        run: |
-          mkdir -p desktop/tauri/src-tauri/bin
-
-          # Copy the actual binary for this platform as a resource
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cp "out/${APP_NAME}-windows-${{ matrix.arch }}.exe" "desktop/tauri/src-tauri/bin/qbit-manage-windows-${{ matrix.arch }}.exe"
-          elif [[ "${{ runner.os }}" == "macOS" ]]; then
-            cp "out/${APP_NAME}-macos-${{ matrix.arch }}" "desktop/tauri/src-tauri/bin/qbit-manage-macos-${{ matrix.arch }}"
-            chmod +x "desktop/tauri/src-tauri/bin/qbit-manage-macos-${{ matrix.arch }}"
-          else
-            cp "out/${APP_NAME}-linux-${{ matrix.arch }}" "desktop/tauri/src-tauri/bin/qbit-manage-linux-${{ matrix.arch }}"
-            chmod +x "desktop/tauri/src-tauri/bin/qbit-manage-linux-${{ matrix.arch }}"
-          fi
-
-      - name: Update Tauri version files
-        working-directory: desktop/tauri/src-tauri
-        shell: bash
-        run: |
-          # Run cargo check to trigger build script and update version files
-          cargo check
-
-      - name: Build Tauri CLI
-        working-directory: desktop/tauri/src-tauri
-        shell: bash
-        run: |
-          # Install Tauri 2 CLI (project migrated to Tauri v2 config & deps)
-          cargo install tauri-cli --version ^2 --locked --force
-
-      - name: Build Tauri app (initial attempt)
-        working-directory: desktop/tauri/src-tauri
-        shell: bash
-        run: |
-          # Build with explicit bundle targets for this platform
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cargo tauri build --target x86_64-pc-windows-msvc --bundles nsis
-          elif [[ "${{ runner.os }}" == "macOS" ]]; then
-            cargo tauri build --bundles app,dmg
-          else
-            cargo tauri build --bundles deb
-          fi
-        continue-on-error: true
-        id: tauri-build
-
-      - name: Wait before retry (macOS DMG recovery)
-        if: steps.tauri-build.outcome == 'failure' && runner.os == 'macOS'
-        run: sleep 30
-        shell: bash
-
-      - name: Wait before retry (build recovery)
-        if: steps.tauri-build.outcome == 'failure'
-        run: sleep 30
-        shell: bash
-
-      - name: Retry Tauri build on failure (attempt 2)
-        if: steps.tauri-build.outcome == 'failure'
-        working-directory: desktop/tauri/src-tauri
-        shell: bash
-        run: |
-          # Build with explicit bundle targets for this platform
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cargo tauri build --target x86_64-pc-windows-msvc --bundles nsis
-          elif [[ "${{ runner.os }}" == "macOS" ]]; then
-            cargo tauri build --bundles app,dmg
-          else
-            cargo tauri build --bundles deb
-          fi
-        continue-on-error: true
-        id: tauri-build-retry1
-
-      - name: Wait before final retry (build recovery)
-        if: steps.tauri-build-retry1.outcome == 'failure'
-        run: sleep 30
-        shell: bash
-
-      - name: Final retry Tauri build on failure (attempt 3)
-        if: steps.tauri-build-retry1.outcome == 'failure'
-        working-directory: desktop/tauri/src-tauri
-        shell: bash
-        run: |
-          # Build with explicit bundle targets for this platform
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cargo tauri build --target x86_64-pc-windows-msvc --bundles nsis
-          elif [[ "${{ runner.os }}" == "macOS" ]]; then
-            cargo tauri build --bundles app,dmg
-          else
-            cargo tauri build --bundles deb
-          fi
-
-      - name: Fail if all Tauri build attempts failed
-        if: steps.tauri-build.outcome == 'failure' && steps.tauri-build-retry1.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "❌ Tauri build failed after all attempts"
-          exit 1
-
-      - name: Set BUILD_ARCH for artifact naming
-        shell: bash
-        run: |
-          echo "BUILD_ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-
-      - name: Upload build outputs (binary + Tauri bundles)
-        uses: actions/upload-artifact@v7
-        with:
-          name: build-outputs-${{ runner.os }}-${{ env.BUILD_ARCH }}
-          path: |
-            out/**
-            desktop/tauri/src-tauri/target/**/release/bundle/**
-          if-no-files-found: error
-          retention-days: 7
-          compression-level: 0
-
-  prepare-release-assets:
-    runs-on: ubuntu-latest
-    needs: build-binaries
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - name: Download and collect all build outputs
-        uses: actions/download-artifact@v8
-        with:
-          pattern: build-outputs-*
-          path: collected
-          merge-multiple: true
-
-      - name: Filter and rename files for release
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p release-assets
-
-          echo "=== Collecting server binaries (standalone executables) ==="
-          # Copy server binaries with error checking
-          server_files=(
-            "qbit-manage-linux-amd64"
-            "qbit-manage-linux-arm64"
-            "qbit-manage-macos-arm64"
-            "qbit-manage-macos-x86_64"
-            "qbit-manage-windows-amd64.exe"
-          )
-
-          for server_file in "${server_files[@]}"; do
-            if find collected -name "$server_file" -exec cp {} release-assets/ \; -print | grep -q .; then
-              echo "✓ Found and copied: $server_file"
-            else
-              echo "⚠️  Warning: $server_file not found"
-            fi
-          done
-
-          echo "=== Processing installer files (desktop app packages) ==="
-
-          # Linux .deb installer
-          deb_count=$(find collected -name "*.deb" -exec cp {} release-assets/ \; -print | wc -l)
-          if [ "$deb_count" -gt 0 ]; then
-            echo "✓ Found $deb_count .deb installer(s)"
-            for file in release-assets/*.deb; do
-              if [ -f "$file" ]; then
-                basename=$(basename "$file" .deb)
-                mv "$file" "release-assets/${basename}-desktop-installer.deb"
-                echo "  → Renamed to: ${basename}-desktop-installer.deb"
-              fi
-            done
-          else
-            echo "⚠️  Warning: No .deb installers found"
-          fi
-
-          # macOS .dmg installers
-          dmg_count=$(find collected -name "*.dmg" -exec cp {} release-assets/ \; -print | wc -l)
-          if [ "$dmg_count" -gt 0 ]; then
-            echo "✓ Found $dmg_count .dmg installer(s)"
-            for file in release-assets/*.dmg; do
-              if [ -f "$file" ]; then
-                basename=$(basename "$file" .dmg)
-                mv "$file" "release-assets/${basename}-desktop-installer.dmg"
-                echo "  → Renamed to: ${basename}-desktop-installer.dmg"
-              fi
-            done
-          else
-            echo "⚠️  Warning: No .dmg installers found"
-          fi
-
-          # Windows .exe installer
-          exe_count=$(find collected -name "*-setup.exe" -exec cp {} release-assets/ \; -print | wc -l)
-          if [ "$exe_count" -gt 0 ]; then
-            echo "✓ Found $exe_count .exe installer(s)"
-            for file in release-assets/*-setup.exe; do
-              if [ -f "$file" ]; then
-                basename=$(basename "$file" -setup.exe)
-                mv "$file" "release-assets/${basename}-desktop-installer-setup.exe"
-                echo "  → Renamed to: ${basename}-desktop-installer-setup.exe"
-              fi
-            done
-          else
-            echo "⚠️  Warning: No .exe installers found"
-          fi
-
-          echo "=== File processing completed ==="
-
-      - name: Display final release assets
-        run: |
-          echo "=== Final Release Assets ==="
-          ls -la release-assets/
-          echo ""
-          echo "=== File Count Summary ==="
-          echo "Server binaries: $(find release-assets -name "qbit-manage-*" -not -name "*desktop*" | wc -l)"
-          echo "Desktop installers: $(find release-assets -name "*desktop-installer*" | wc -l)"
-
-      - name: Upload final release assets
-        uses: actions/upload-artifact@v7
-        with:
-          name: qbit-manage-release-assets
-          path: release-assets/*
-          if-no-files-found: error
-          compression-level: 6
-
-      - name: Clean up temporary build artifacts
-        uses: actions/github-script@v9
-        with:
-          script: |
-            // Get all artifacts from this workflow run
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.runId,
-            });
-
-            // Delete temporary build artifacts, keep only the final release assets
-            for (const artifact of artifacts.data.artifacts) {
-              if (artifact.name.startsWith('build-outputs-')) {
-                console.log(`Deleting temporary artifact: ${artifact.name}`);
-                try {
-                  await github.rest.actions.deleteArtifact({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    artifact_id: artifact.id,
-                  });
-                  console.log(`✓ Successfully deleted: ${artifact.name}`);
-                } catch (error) {
-                  console.log(`⚠️  Failed to delete ${artifact.name}: ${error.message}`);
-                }
-              } else {
-                console.log(`✓ Keeping final artifact: ${artifact.name}`);
-              }
-            }
-
   docker-release:
     runs-on: ubuntu-latest
     # Upstream-only: DOCKER_HUB_USERNAME / GHCR_TOKEN aren't configured on forks.
@@ -475,40 +83,33 @@ jobs:
             ghcr.io/${{ env.OWNER_LC }}/qbit_manage:${{ steps.get_version.outputs.VERSION }}
             ghcr.io/${{ env.OWNER_LC }}/qbit_manage:latest
 
-  create-release:
+  publish-release:
+    name: Publish draft release from Release PR
     runs-on: ubuntu-latest
-    needs: [prepare-release-assets, docker-release]
+    needs: [docker-release]
+    # Upstream-only: the draft release + PAT live on the upstream repo.
+    if: github.repository == 'StuffAnThings/qbit_manage'
     permissions:
       contents: write
     steps:
-      - name: Check Out Repo
-        uses: actions/checkout@v7
-
       - name: Get the version
         id: get_version
         run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
-      - name: Download prepared release assets
-        uses: actions/download-artifact@v8
-        with:
-          name: qbit-manage-release-assets
-          path: release-assets
-
-      - name: Display assets to be released
+      - name: Publish the draft release (keep its notes + assets)
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+          GH_REPO: ${{ github.repository }}
         run: |
-          echo "=== Assets to be released ==="
-          ls -la release-assets/
-          echo ""
-          echo "=== Individual files that will be uploaded ==="
-          find release-assets -type f -exec basename {} \;
+          TAG="${{ steps.get_version.outputs.VERSION }}"
 
-      - name: Create release with individual assets
-        id: create_release
-        uses: softprops/action-gh-release@v3
-        with:
-          body_path: CHANGELOG
-          token: ${{ secrets.PAT }}
-          tag_name: ${{ steps.get_version.outputs.VERSION }}
-          files: release-assets/*
-          draft: false
-          prerelease: false
+          # release-pr.yml created this draft with the standalone binaries +
+          # auto-generated changelog already attached. Just flip it to published;
+          # do NOT touch the body or assets.
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::error::No release found for tag $TAG — expected a draft created by release-pr.yml."
+            exit 1
+          fi
+
+          gh release edit "$TAG" --draft=false --latest
+          echo "Published release $TAG"

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -28,9 +28,11 @@ The workflow:
 - Opens a PR from `release/v<NEW> → master` titled `Release v<NEW>`.
 - PR body is auto-generated from `git log master..release/v<NEW> --oneline`,
   grouped by Conventional Commit prefix (`feat`, `fix`, `chore`, etc.).
+- Builds the 5-platform binary + Tauri desktop bundle matrix via the reusable
+  `build-binaries.yml` workflow.
 - Creates a **draft** GitHub release tagged `v<NEW>` (`target_commitish`
-  set to the release branch) with the same notes. The tag is **not pushed**
-  yet — the draft exists only as a preview.
+  set to the release branch) with the auto-generated notes and built assets
+  attached. The tag is **not pushed** yet — the draft is a testable preview.
 
 > **Repo setting prerequisite:** enable **Settings → General → Pull Requests
 > → Automatically delete head branches** so the `release/v<NEW>` branch is
@@ -40,7 +42,8 @@ The workflow:
 ### Step 2 — Operator Review and Merge
 
 The operator:
-1. Reviews the release PR and checks the draft release notes.
+1. Reviews the release PR, checks the draft release notes, and optionally downloads
+   and tests the binaries attached to the draft GitHub release.
 2. Verifies all CI checks are green on the PR.
 3. Merges `release/v<NEW>` to `master`. **Use `Rebase and merge`** (not
    squash) so the individual Conventional Commit messages (`feat:`,
@@ -64,11 +67,48 @@ Four workflows fire in parallel after the master push:
 |----------|-------------|
 | `tag.yml` | Reads `VERSION`, creates and pushes the `v<X.Y.Z>` tag via `Kometa-Team/tag-new-version`. |
 | `pypi-publish.yml` | Triggered by the new `v*` tag; builds the Python package and publishes to PyPI via trusted publishing (OIDC, no API token needed). |
-| `version.yml` | Builds standalone PyInstaller binaries (Linux amd64/arm64, Windows, macOS) and the Tauri desktop bundles; attaches them to the GitHub release. |
+| `version.yml` | Triggered by the `v*` tag; builds + pushes the Docker image, then publishes the draft GitHub release that `release-pr.yml` already prepared — flips it from draft to published. Does **not** rebuild binaries. |
 | `update-develop-branch.yml` | Resets `develop` to `master`, bumps `VERSION` to the next patch-develop1 (e.g. `4.7.3-develop1`), force-pushes develop, then triggers `develop.yml` to rebuild Docker develop images. |
 
-The draft release created in Step 1 is promoted to published once `tag.yml`
-pushes the matching tag.
+After `tag.yml` pushes the `v<X.Y.Z>` tag, `version.yml` fires: it builds and
+pushes the Docker image, then publishes the draft release (binaries and notes
+were already attached by `release-pr.yml` in Step 1).
+
+---
+
+## Develop Builds & PR Artifacts
+
+### Rolling develop pre-release
+
+Every push to `develop` (excluding doc-only paths) triggers `develop.yml`, which:
+
+1. Builds the full 5-platform binary + Tauri bundle matrix via `build-binaries.yml`.
+2. Pushes the `:develop` Docker image.
+3. Deletes and recreates the `latest-develop` rolling GitHub pre-release at the
+   current develop HEAD (`gh release delete latest-develop --cleanup-tag`, then
+   `gh release create latest-develop --prerelease --latest=false ...`).
+
+The `latest-develop` tag is intentionally non-`v*` so it never triggers `tag.yml`,
+`version.yml`, or `pypi-publish.yml`. Use it to grab a development binary without
+waiting for a full release.
+
+### PR cross-platform artifacts
+
+By default, PRs do **not** run the 5-OS binary build — unlabeled PRs cost zero
+runner minutes. When a maintainer adds the **`build` label** to a PR, `pr-build.yml`
+triggers the full matrix via `build-binaries.yml` using the PR's head SHA. The
+resulting `qbit-manage-release-assets` artifact is available for download from the
+**Actions → PR Build Artifacts** workflow run, letting reviewers test all platforms
+before merge. A concurrency group cancels superseded runs when new commits land on
+the same labeled PR.
+
+### Reusable build workflow (`build-binaries.yml`)
+
+`build-binaries.yml` is a `workflow_call` reusable workflow — the single source of
+truth for the PyInstaller + Tauri matrix. All three callers (`release-pr.yml`,
+`develop.yml`, `pr-build.yml`) pass a `ref` input (branch / tag / SHA). The
+workflow produces one consolidated `qbit-manage-release-assets` artifact containing
+the 5 server binaries plus the per-platform desktop installer bundles.
 
 ---
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -26,7 +26,7 @@ The workflow:
   copy at the snapshot point).
 - Writes the new version to `VERSION` on the release branch and pushes it.
 - Opens a PR from `release/v<NEW> → master` titled `Release v<NEW>`.
-- PR body is auto-generated from `git log master..release/v<NEW> --oneline`,
+- PR body is auto-generated from `git log origin/master..HEAD --oneline --no-merges`,
   grouped by Conventional Commit prefix (`feat`, `fix`, `chore`, etc.).
 - Builds the 5-platform binary + Tauri desktop bundle matrix via the reusable
   `build-binaries.yml` workflow.
@@ -61,7 +61,9 @@ The operator:
 
 ### Step 3 — Post-Merge Automation (CI, auto-triggered on master push)
 
-Four workflows fire in parallel after the master push:
+The master push triggers `tag.yml` (and `update-develop-branch.yml`) directly;
+`tag.yml` then pushes the `v<X.Y.Z>` tag, which in turn triggers `version.yml`
+and `pypi-publish.yml`. The cascade is two steps, not a single parallel burst:
 
 | Workflow | What it does |
 |----------|-------------|
@@ -162,17 +164,16 @@ branch, and opens the PR from that branch. `develop` is not modified during this
 
 ## CI Gates
 
-Every PR to `develop` runs the `develop.yml` workflow, which includes:
+Every PR to `develop` (and to `master`) is gated by `tests.yml` (triggered by
+`pull_request` to master/main/develop), which runs pytest across Python
+3.10–3.14. That is the only CI job that must pass before merge.
 
-- **Ruff** — lint and format check (non-zero exit blocks merge)
-- **yamllint** — strict YAML validation for any changed YAML files
-- **pytest** — full test suite (~168 tests)
-- **Docker build** — multi-arch image build (amd64, arm64, arm/v7) to catch
-  import and dependency errors before release
+Ruff (lint/format) and yamllint are enforced as local pre-commit hooks, not as
+CI jobs. `develop.yml` is a post-merge workflow triggered by
+`push: branches:[develop]` — it is not a PR gate.
 
-The Release PR to `master` must also pass these same checks. Branch protection
-on `master` requires at least one maintainer approval and all status checks
-green.
+Branch protection on `master` requires at least one maintainer approval and all
+status checks green.
 
 ---
 
@@ -197,7 +198,7 @@ would accidentally include live tracker credentials sourced from a local
 
 | Secret | Used by | Purpose |
 |--------|---------|---------|
-| `PAT` | `tag.yml`, `update-develop-branch.yml` | Push tags and force-push develop (bypasses branch protection) |
+| `PAT` | `tag.yml`, `update-develop-branch.yml`, `version.yml`, `release-pr.yml` | Push tags, force-push develop, publish releases, and open release PRs (bypasses branch protection) |
 | `GITHUB_TOKEN` | Most workflows | Default Actions token for read operations and PR creation |
 | PyPI OIDC | `pypi-publish.yml` | Trusted publishing — no stored API token |
 

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -170,11 +170,13 @@ chore(deps): bump ruff from 0.14.5 to 0.14.6
 4. Describe what your PR does and link any related issues.
 5. A maintainer will review; CI must be green before merge.
 
-> **Cross-platform test artifacts:** If your change affects platform-specific
-> behavior, ask a maintainer to add the **`build` label** to your PR. This
-> triggers the full 5-platform PyInstaller + Tauri bundle matrix and uploads a
-> `qbit-manage-release-assets` artifact to the workflow run so the team can
-> test all platforms before merge.
+> **PR build artifacts:** PRs from the repo owner and org members build
+> automatically on every push — the full 5-platform PyInstaller + Tauri bundle
+> matrix (downloadable `qbit-manage-release-assets` artifact) plus a
+> `ghcr.io/<owner>/qbit_manage:pr-<number>` docker image. For everyone else
+> (outside collaborators, contributors, fork PRs), ask a maintainer to add the
+> **`build` label** to trigger the same artifacts before merge. Fork PRs get the
+> binary artifacts but not the docker image (no registry push from a fork).
 
 For the release process (merging `develop → master`, tagging, PyPI publish),
 see [`DEVELOPER.md`](../DEVELOPER.md).

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -170,6 +170,12 @@ chore(deps): bump ruff from 0.14.5 to 0.14.6
 4. Describe what your PR does and link any related issues.
 5. A maintainer will review; CI must be green before merge.
 
+> **Cross-platform test artifacts:** If your change affects platform-specific
+> behavior, ask a maintainer to add the **`build` label** to your PR. This
+> triggers the full 5-platform PyInstaller + Tauri bundle matrix and uploads a
+> `qbit-manage-release-assets` artifact to the workflow run so the team can
+> test all platforms before merge.
+
 For the release process (merging `develop → master`, tagging, PyPI publish),
 see [`DEVELOPER.md`](../DEVELOPER.md).
 

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Build the standalone qbit-manage binary (and, by default, the Tauri desktop
+# bundle) locally for the current platform, mirroring the CI build in
+# .github/workflows/build-binaries.yml. Useful for testing a release artifact
+# without pushing or waiting on CI.
+set -euo pipefail
+
+readonly APP_NAME="qbit-manage"
+readonly ENTRY="qbit_manage.py"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly REPO_ROOT
+readonly TAURI_DIR="${REPO_ROOT}/desktop/tauri/src-tauri"
+
+build_desktop=1
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build-local.sh [--skip-desktop] [--help]
+
+Builds the standalone server binary with PyInstaller for the current OS/arch,
+then (by default) the Tauri desktop bundle for this platform.
+
+Options:
+  --skip-desktop   Build only the PyInstaller server binary (no Rust/Tauri).
+  --help           Show this help.
+
+Outputs land in ./out/ (server binary) and the Tauri target bundle dir.
+The desktop build requires the Rust toolchain plus the platform's Tauri
+prerequisites (see https://tauri.app/start/prerequisites/).
+EOF
+}
+
+detect_platform() {
+  local uname_s uname_m
+  uname_s="$(uname -s)"
+  uname_m="$(uname -m)"
+
+  case "${uname_s}" in
+    Linux) os="linux" ;;
+    Darwin) os="macos" ;;
+    MINGW* | MSYS* | CYGWIN*) os="windows" ;;
+    *)
+      printf 'Unsupported OS: %s\n' "${uname_s}" >&2
+      exit 1
+      ;;
+  esac
+
+  case "${uname_m}" in
+    x86_64 | amd64)
+      arch=$([[ "${os}" == "macos" ]] && echo "x86_64" || echo "amd64")
+      ;;
+    arm64 | aarch64) arch="arm64" ;;
+    *)
+      printf 'Unsupported arch: %s\n' "${uname_m}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+build_server_binary() {
+  command -v pyinstaller >/dev/null 2>&1 || {
+    printf 'pyinstaller not found. Install it: pip install pyinstaller\n' >&2
+    exit 1
+  }
+
+  # `:` everywhere this script runs (Windows here means git-bash, which still
+  # accepts `:` for PyInstaller add-data on recent versions).
+  local sep=":"
+  local icon_arg=""
+  if [[ "${os}" == "macos" && -f "${REPO_ROOT}/icons/qbm_logo.icns" ]]; then
+    icon_arg="--icon=icons/qbm_logo.icns"
+  elif [[ -f "${REPO_ROOT}/icons/qbm_logo.png" ]]; then
+    icon_arg="--icon=icons/qbm_logo.png"
+  elif [[ -f "${REPO_ROOT}/icons/qbm_logo.ico" ]]; then
+    icon_arg="--icon=icons/qbm_logo.ico"
+  fi
+
+  printf '==> Building server binary (%s-%s)\n' "${os}" "${arch}"
+  (
+    cd "${REPO_ROOT}"
+    # shellcheck disable=SC2086  # icon_arg is intentionally word-split (may be empty)
+    pyinstaller --noconfirm --clean --onefile \
+      --name "${APP_NAME}" \
+      --add-data "web-ui${sep}web-ui" \
+      --add-data "config/config.yml.sample${sep}config" \
+      --add-data "icons/qbm_logo.png${sep}." \
+      --add-data "VERSION${sep}." \
+      --add-data "docs${sep}docs" \
+      ${icon_arg} \
+      "${ENTRY}"
+
+    mkdir -p out
+    if [[ "${os}" == "windows" ]]; then
+      mv "dist/${APP_NAME}.exe" "out/${APP_NAME}-windows-${arch}.exe"
+    else
+      mv "dist/${APP_NAME}" "out/${APP_NAME}-${os}-${arch}"
+    fi
+  )
+  printf '==> Server binary written to out/\n'
+}
+
+build_desktop_bundle() {
+  command -v cargo >/dev/null 2>&1 || {
+    printf 'cargo (Rust) not found. Install Rust or re-run with --skip-desktop.\n' >&2
+    printf 'See https://tauri.app/start/prerequisites/\n' >&2
+    exit 1
+  }
+
+  printf '==> Preparing Tauri sidecar binary\n'
+  mkdir -p "${TAURI_DIR}/bin"
+  if [[ "${os}" == "windows" ]]; then
+    cp "${REPO_ROOT}/out/${APP_NAME}-windows-${arch}.exe" "${TAURI_DIR}/bin/${APP_NAME}-windows-${arch}.exe"
+  else
+    cp "${REPO_ROOT}/out/${APP_NAME}-${os}-${arch}" "${TAURI_DIR}/bin/${APP_NAME}-${os}-${arch}"
+    chmod +x "${TAURI_DIR}/bin/${APP_NAME}-${os}-${arch}"
+  fi
+
+  printf '==> Building Tauri desktop bundle (this can take a while)\n'
+  (
+    cd "${TAURI_DIR}"
+    cargo check
+    command -v cargo-tauri >/dev/null 2>&1 || cargo install tauri-cli --version "^2" --locked
+    case "${os}" in
+      windows) cargo tauri build --bundles nsis ;;
+      macos) cargo tauri build --bundles app,dmg ;;
+      *) cargo tauri build --bundles deb ;;
+    esac
+  )
+  printf '==> Desktop bundle written under %s/target/release/bundle/\n' "${TAURI_DIR}"
+}
+
+main() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --skip-desktop) build_desktop=0 ;;
+      --help | -h)
+        usage
+        exit 0
+        ;;
+      *)
+        printf 'Unknown argument: %s\n' "$1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+    shift
+  done
+
+  local os arch
+  detect_platform
+  build_server_binary
+  if [[ "${build_desktop}" -eq 1 ]]; then
+    build_desktop_bundle
+  fi
+  printf '==> Done.\n'
+}
+
+main "$@"

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -12,6 +12,8 @@ readonly REPO_ROOT
 readonly TAURI_DIR="${REPO_ROOT}/desktop/tauri/src-tauri"
 
 build_desktop=1
+os=""
+arch=""
 
 usage() {
   cat <<'EOF'
@@ -63,11 +65,13 @@ build_server_binary() {
     exit 1
   }
 
-  # `:` everywhere this script runs (Windows here means git-bash, which still
-  # accepts `:` for PyInstaller add-data on recent versions).
+  # PyInstaller add-data uses ';' on native Windows, ':' elsewhere — match CI.
   local sep=":"
+  [[ "${os}" == "windows" ]] && sep=";"
   local icon_arg=""
-  if [[ "${os}" == "macos" && -f "${REPO_ROOT}/icons/qbm_logo.icns" ]]; then
+  if [[ "${os}" == "windows" ]]; then
+    icon_arg="--icon=icons/qbm_logo.ico"
+  elif [[ "${os}" == "macos" ]]; then
     icon_arg="--icon=icons/qbm_logo.icns"
   elif [[ -f "${REPO_ROOT}/icons/qbm_logo.png" ]]; then
     icon_arg="--icon=icons/qbm_logo.png"
@@ -121,7 +125,7 @@ build_desktop_bundle() {
     cargo check
     command -v cargo-tauri >/dev/null 2>&1 || cargo install tauri-cli --version "^2" --locked
     case "${os}" in
-      windows) cargo tauri build --bundles nsis ;;
+      windows) cargo tauri build --target x86_64-pc-windows-msvc --bundles nsis ;;
       macos) cargo tauri build --bundles app,dmg ;;
       *) cargo tauri build --bundles deb ;;
     esac
@@ -146,7 +150,6 @@ main() {
     shift
   done
 
-  local os arch
   detect_platform
   build_server_binary
   if [[ "${build_desktop}" -eq 1 ]]; then


### PR DESCRIPTION
> **Draft.** Core rework + a 5-auditor adversarial pass are complete. Opening as draft for review.

## What & why
Reworks the release pipeline so the **draft GitHub release created by `release-pr.yml` is the single source of truth** — built once, testable before merge, then published as-is. `version.yml` no longer rebuilds binaries or reads the `CHANGELOG` file.

### Flow
- **`build-binaries.yml`** (NEW, `workflow_call`, input `ref`) — single source of the 5-platform PyInstaller + Tauri matrix → one `qbit-manage-release-assets` artifact. Replaces 3 duplicated copies.
- **`release-pr.yml`** — snapshots develop → `release/vX.Y.Z`, opens PR to master, builds assets via the reusable workflow, creates a **draft** release `vX.Y.Z` with binaries + auto-generated notes attached (testable pre-merge).
- **`tag.yml`** — on merge to master, pushes the real `vX.Y.Z` tag.
- **`version.yml`** — on `v*` tag: builds/pushes Docker, then **publishes the draft** (`gh release edit --draft=false --latest`). No rebuild, no CHANGELOG.
- **`develop.yml`** — every develop push refreshes a rolling **`latest-develop`** pre-release (delete+recreate at HEAD; non-`v*` tag so it never trips release workflows). Still pushes `:develop` Docker.
- **`pr-build.yml`** (NEW) — owner/org-member PRs build automatically on every push (full matrix artifacts + a `ghcr.io/<owner>/qbit_manage:pr-<number>` image for same-repo PRs); everyone else needs a maintainer to add the **`build`** label. Default PRs cost zero minutes.
- **`scripts/build-local.sh`** (NEW) — full-parity local build (server binary + Tauri).

## Decisions (for posterity)
- Build location: in `release-pr` (testable pre-merge); `version.yml` only publishes + docker.
- Develop: rolling full-matrix pre-release `latest-develop`.
- PR builds: auto for owner/members; label-gated (`build`) for everyone else; per-PR `pr-N` GHCR image (same-repo only).
- Refactor: one reusable `workflow_call` build (single matrix source).
- Local script: full parity incl. desktop bundles.
- Fork protection: every build path gated to the upstream repo; `pull_request` (no secret exposure); label/association gate; fork PRs get artifacts but no registry push.

## 5-auditor adversarial review — applied
- [x] HIGH: `version.yml` publish — `GH_TOKEN` PAT→GITHUB_TOKEN fallback + `if: always()` (Docker failure no longer strands the draft)
- [x] HIGH: `release-pr.yml` — `release_notes_override` via `env:` (shell-injection); upstream guards; refuse to overwrite a published release; draft `commit:` uses SHA not the auto-deleted branch
- [x] HIGH: `pr-build.yml` — label path triggers on `labeled` only (TOCTOU)
- [x] MED: `bump-version-develop.yml` — `[skip ci]` kills the double full-matrix build per develop merge
- [x] MED: `develop.yml` — docker checkout `github.sha`; job-level least-privilege perms; `gh release delete` only when it exists
- [x] MED: `build-binaries.yml` — Tauri attempt-3 retry fixed (no false-fail); tauri-cli cache + drop `--force`; macOS double-sleep; compression 6
- [x] Docs accuracy (CI gate = tests.yml/pytest; tag cascade; PAT consumers; `--no-merges`)
- [x] Comment prune (why-not-what)
- [ ] Follow-up (separate PR): SHA-pin third-party actions (`dtolnay/rust-toolchain@stable`, `ncipollo`, `swatinem/rust-cache`) — pre-existing, Renovate-managed

## Known tradeoffs (by design)
- Rolling `latest-develop` delete+recreate resets asset permalinks / notifies watchers each merge.
- With `[skip ci]` on the bump commit, the develop prerelease reflects the merge commit's VERSION (lags the `-developN` bump by one), in exchange for eliminating the double build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)