### PR TITLE
fix: standalone binary crash on Python 3.14 (multiprocessing start method) (#1282)

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -117,6 +117,39 @@ jobs:
             mv "dist/${APP_NAME}" "out/${APP_NAME}-linux-${{ matrix.arch }}"
           fi
 
+      # gh#1282: the frozen binary crashed at multiprocessing.Manager() because Python
+      # 3.14 changed the Linux default start method to 'forkserver' (incompatible with
+      # the PyInstaller bootloader). Nothing ran the built binary, so it shipped broken.
+      # Exercise the Manager() init path on Linux to catch this class of regression.
+      - name: Smoke test binary (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -uo pipefail
+          BIN="out/${APP_NAME}-linux-${{ matrix.arch }}"
+          chmod +x "$BIN"
+          mkdir -p smoke
+          cat > smoke/config.yml <<'EOF'
+          commands:
+            dry_run: true
+          qbt:
+            host: 127.0.0.1:1
+          EOF
+          # -r exits after one run; --web-server=False keeps the process from hanging.
+          # The unreachable qbt host makes the run fail fast, but only *after*
+          # multiprocessing.Manager() has initialized.
+          out="$(timeout 120 "$BIN" -r --web-server=False --config-dir smoke 2>&1)" || true
+          printf '%s\n' "$out"
+          if printf '%s\n' "$out" | grep -qiE 'forkserver|Connection reset by peer|multiprocessing/(managers|forkserver|connection)\.py'; then
+            echo "::error::multiprocessing start-method regression (gh#1282): Manager() failed in the frozen binary"
+            exit 1
+          fi
+          if ! printf '%s\n' "$out" | grep -qi 'Run Mode'; then
+            echo "::error::binary did not reach the run stage (Manager() init may have failed)"
+            exit 1
+          fi
+          echo "Smoke test passed: multiprocessing.Manager() initialized in the frozen binary."
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -67,9 +67,9 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            echo "SEP=;" >> $GITHUB_OUTPUT
+            echo "SEP=;" >> "$GITHUB_OUTPUT"
           else
-            echo "SEP=:" >> $GITHUB_OUTPUT
+            echo "SEP=:" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build (PyInstaller onefile)
@@ -299,7 +299,7 @@ jobs:
       - name: Set BUILD_ARCH for artifact naming
         shell: bash
         run: |
-          echo "BUILD_ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "BUILD_ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
 
       - name: Upload build outputs (binary + Tauri bundles)
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -125,7 +125,7 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          set -uo pipefail
+          set -euo pipefail
           BIN="out/${APP_NAME}-linux-${{ matrix.arch }}"
           chmod +x "$BIN"
           mkdir -p smoke

--- a/qbit_manage.py
+++ b/qbit_manage.py
@@ -719,6 +719,15 @@ def main():
         sys.exit(0)
 
     multiprocessing.freeze_support()
+    # gh#1282: Python 3.14 made 'forkserver' the default start method on Linux,
+    # which fails inside the PyInstaller standalone binary (the forkserver re-execs
+    # the bootloader and the handshake dies with ConnectionResetError). Pin the start
+    # method explicitly per-platform so a future default flip can't silently break us
+    # the same way: 'fork' on Linux (pre-3.14 behaviour), 'spawn' on macOS/Windows.
+    if sys.platform.startswith("linux"):
+        multiprocessing.set_start_method("fork", force=True)
+    else:
+        multiprocessing.set_start_method("spawn", force=True)
     killer = GracefulKiller()
     logger.add_main_handler()
     print_logo(logger)

--- a/qbit_manage.py
+++ b/qbit_manage.py
@@ -723,7 +723,8 @@ def main():
     # which fails inside the PyInstaller standalone binary (the forkserver re-execs
     # the bootloader and the handshake dies with ConnectionResetError). Pin the start
     # method explicitly per-platform so a future default flip can't silently break us
-    # the same way: 'fork' on Linux (pre-3.14 behaviour), 'spawn' on macOS/Windows.
+    # the same way: 'fork' on Linux (pre-3.14 behaviour), 'spawn' everywhere else
+    # (macOS/Windows already default to 'spawn'; safe on any other platform too).
     if sys.platform.startswith("linux"):
         multiprocessing.set_start_method("fork", force=True)
     else:


### PR DESCRIPTION
## Problem

Closes #1282. The standalone (PyInstaller) binary crashes on startup on Linux for 4.9.0/4.9.1:

```
File "qbit_manage.py", line 736, in main
  manager = Manager()
...
ConnectionResetError: [Errno 104] Connection reset by peer
```

`-h`/`-v` work because they exit before `main()` reaches `multiprocessing.Manager()`.

## Root cause

Python 3.14 [changed the default multiprocessing start method](https://docs.python.org/3.14/whatsnew/3.14.html) on Unix (except macOS) from `fork` to `forkserver`. Inside the frozen binary the forkserver process re-execs the PyInstaller bootloader and the handshake fails with `ConnectionResetError`. The binaries are built on Python 3.14, so every Linux standalone run hits this. It is **not** a qBittorrent connection issue — the failure is in Python's internal `multiprocessing` Manager, before any qBit connection.

## Fix

Pin the multiprocessing start method explicitly per platform, right after `freeze_support()`:

- **Linux** → `fork` (restores pre-3.14 behaviour that the binary relied on)
- **macOS / Windows** → `spawn` (their existing default, made explicit)

Setting it explicitly also means a future default flip can't silently break startup again.

## CI regression guard

The build workflow built the binary but never ran it, so the broken binary shipped. Added a Linux smoke-test step to `build-binaries.yml` that runs the freshly built binary through the `Manager()` init path (`-r --web-server=False` against an unreachable qbt host) and fails the job if the multiprocessing traceback appears or the run stage is never reached.

## Testing

- Smoke invocation validated from source: reaches `Run Mode` (i.e. past `Manager()`) and exits cleanly.
- `set_start_method('fork', force=True)` + `Manager()` verified working.
- `actionlint` clean; `pre-commit` (ruff, yaml) passing. Also fixed pre-existing SC2086 (`$GITHUB_OUTPUT`/`$GITHUB_ENV` quoting) in the same workflow.