### PR TITLE
ci: back-merge master into develop instead of force-resetting it

### DIFF
--- a/.github/workflows/update-develop-branch.yml
+++ b/.github/workflows/update-develop-branch.yml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: write   # the final step dispatches develop.yml via `gh workflow run`
 
 jobs:
 
@@ -43,10 +44,11 @@ jobs:
           # Ensure we have the latest remote refs
           git fetch origin
 
-          # Check out develop from the remote tip (no reset --hard; history is preserved)
+          # Align the local develop checkout with its own remote tip. We never reset
+          # develop to master and never force-push, so develop's history is preserved.
           if git show-ref --verify --quiet refs/heads/develop; then
             git checkout develop
-            git reset --hard origin/develop   # align local develop with remote tip, NOT master
+            git reset --hard origin/develop   # local develop -> origin/develop (its own tip), NOT master
           else
             git checkout -b develop origin/develop
           fi
@@ -89,6 +91,10 @@ jobs:
 
           echo "Successfully back-merged master and set develop to $NEW_VERSION"
 
+      # Unconditional dispatch is intentional: the VERSION-bump commit pushed above carries
+      # `[skip ci]`, which suppresses develop.yml's `on: push` trigger even under a PAT push.
+      # So we always dispatch it explicitly. (develop.yml has cancel-in-progress, so on the
+      # rare no-VERSION-change push a redundant auto-trigger would just be superseded.)
       - name: Trigger develop workflow
         if: success()
         run: |

--- a/.github/workflows/update-develop-branch.yml
+++ b/.github/workflows/update-develop-branch.yml
@@ -1,4 +1,7 @@
-# Resets develop to master and bumps the develop VERSION suffix after every push to master.
+# Back-merges master into develop and bumps the develop VERSION suffix after every push to master.
+# Uses a merge (not reset --hard + force-push) so develop's history is preserved: force-rewriting
+# develop every release turned old develop commits into phantom commits on open feature branches
+# and churned develop's git-blame each cycle.
 name: Update Develop Branch
 
 on:
@@ -19,7 +22,7 @@ jobs:
   update-develop:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Upstream-only: force-pushes develop on the upstream repo.
+    # Upstream-only: pushes develop on the upstream repo.
     if: github.repository == 'StuffAnThings/qbit_manage'
 
     steps:
@@ -31,6 +34,8 @@ jobs:
 
       - name: Update develop branch
         run: |
+          set -euo pipefail
+
           # Configure git with GitHub Actions bot credentials
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
@@ -38,52 +43,51 @@ jobs:
           # Ensure we have the latest remote refs
           git fetch origin
 
-          # Check if develop branch exists locally, if not create it
+          # Check out develop from the remote tip (no reset --hard; history is preserved)
           if git show-ref --verify --quiet refs/heads/develop; then
-            echo "Local develop branch exists, checking it out"
             git checkout develop
+            git reset --hard origin/develop   # align local develop with remote tip, NOT master
           else
-            echo "Local develop branch doesn't exist, creating from remote"
             git checkout -b develop origin/develop
           fi
 
-          # Reset develop to master
-          echo "Resetting develop branch to match master..."
-          git reset --hard origin/master
-
-          # Read current version and bump patch
-          CURRENT_VERSION=$(cat VERSION)
-          echo "Current version: $CURRENT_VERSION"
-
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-          NEW_PATCH=$((PATCH + 1))
-          NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}-develop1"
-
-          echo "New version: $NEW_VERSION"
-
-          # Update VERSION file
-          echo "$NEW_VERSION" > VERSION
-
-          # Check if there are changes to commit
-          if git diff --quiet; then
-            echo "No changes to commit"
-            exit 0
-          fi
-
-          # Commit the change
-          git add VERSION
-          git commit -m "Update VERSION to $NEW_VERSION [skip ci]"
-
-          # Push develop branch (force push since we reset to master)
-          # Note: This requires PAT_TOKEN secret with admin privileges to bypass branch protection
-          echo "Pushing changes to develop branch..."
-          if ! git push --force origin develop; then
-            echo "Failed to push to develop branch. This may be due to branch protection rules."
-            echo "Ensure PAT_TOKEN secret is set with admin privileges or disable branch protection for this workflow."
+          # Back-merge master into develop. -X theirs makes master's content win on conflict
+          # (so develop matches the just-released code) while keeping develop's commit history
+          # and any dev-only commits that landed after the release branch was cut.
+          echo "Back-merging master into develop..."
+          if ! git merge --no-edit -X theirs origin/master; then
+            echo "::error::merge of master into develop failed beyond -X theirs; manual resolution required"
+            git merge --abort || true
             exit 1
           fi
 
-          echo "Successfully updated develop branch to $NEW_VERSION"
+          # Bump the develop VERSION suffix off the released version.
+          CURRENT_VERSION=$(cat VERSION)
+          echo "Current version: $CURRENT_VERSION"
+          BASE_VERSION="${CURRENT_VERSION%%-*}"   # strip any -developN suffix
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+          NEW_PATCH=$((PATCH + 1))
+          NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}-develop1"
+          echo "New version: $NEW_VERSION"
+
+          echo "$NEW_VERSION" > VERSION
+          git add VERSION
+          if ! git diff --cached --quiet; then
+            git commit -m "Update VERSION to $NEW_VERSION [skip ci]"
+          else
+            echo "VERSION already at $NEW_VERSION; nothing to commit"
+          fi
+
+          # Regular push (no force). develop only moves forward now.
+          # Note: requires PAT with permission to push to develop if it is protected.
+          echo "Pushing develop..."
+          if ! git push origin develop; then
+            echo "Failed to push to develop branch. This may be due to branch protection rules."
+            echo "Ensure PAT secret is set with permission to push to develop, or allow this workflow."
+            exit 1
+          fi
+
+          echo "Successfully back-merged master and set develop to $NEW_VERSION"
 
       - name: Trigger develop workflow
         if: success()


### PR DESCRIPTION
## Problem

`update-develop-branch.yml` runs on every push to `master` and hard-resets `develop` to `origin/master` then force-pushes it. That **rewrites `develop`'s history every release**. Consequences we hit in practice:

- Any open feature branch cut from the pre-release develop suddenly carries the *old* develop commits as "phantom" changes (they're no longer ancestors of the rewritten develop). Result: 45–55 bogus commits and mass merge conflicts on PRs that never touched that code. (Just cleaned this up on #1159/#1160/#1161/#1279 — each had ~50 phantom commits.)
- `git blame` on develop is re-attributed to the reset every cycle, so historical authorship on develop churns each release.

## Fix

Replace the force-reset with a **back-merge** of master into develop (no force-push):

- `git merge --no-edit -X theirs origin/master` — released content wins on conflict, keeping develop's content matching the just-released code (same end state the reset produced) while **preserving develop's history** and any dev-only commits that landed after the release branch was cut.
- Bump the `-developN` suffix, then a **regular** `git push origin develop`.
- develop now only ever moves forward, so open feature branches stay clean and blame is durable.
- Also added `set -euo pipefail` to the step.

## Notes

- Requires the PAT to have push permission to `develop` (previously it needed admin to force-push a protected branch; now it just needs normal push).
- This is **Option A** of the two approaches discussed. Option B (merge-commit releases for granular *master* blame) was considered and deferred — it needs repo-settings + `release-pr.yml` changes and makes master busier; develop already preserves full per-PR history under this change, so blame data is never lost.
