### PR TITLE
feat(ci): auto-label issues on develop merge, close on release

### DIFF
--- a/.github/workflows/issue-lifecycle.yml
+++ b/.github/workflows/issue-lifecycle.yml
@@ -78,7 +78,8 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const version = context.payload.pull_request.head.ref.replace('release/', '');
+            const pr = context.payload.pull_request;
+            const version = pr.head.ref.replace('release/', '');
             const issues = await github.paginate(github.rest.issues.listForRepo, {
               ...context.repo, state: 'open', labels: 'status:added-to-develop', per_page: 100,
             });
@@ -88,7 +89,9 @@ jobs:
               if (issue.pull_request) continue;
               await github.rest.issues.createComment({
                 ...context.repo, issue_number: issue.number,
-                body: `Released in [${version}](https://github.com/${context.repo.owner}/${context.repo.repo}/releases/tag/${version}). Closing — please open a new issue if this persists on the latest release.`,
+                // Link the release PR (public now) rather than /releases/tag/${version}:
+                // at merge time the release is still a draft and the tag may not exist yet.
+                body: `Shipped to \`master\` for the ${version} release (${pr.html_url}). Closing — please open a new issue if this persists on the latest release.`,
               });
               await github.rest.issues.update({ ...context.repo, issue_number: issue.number, state: 'closed', state_reason: 'completed' });
               core.info(`Closed #${issue.number}.`);

--- a/.github/workflows/issue-lifecycle.yml
+++ b/.github/workflows/issue-lifecycle.yml
@@ -1,0 +1,97 @@
+# Tracks issue lifecycle across the develop -> master release flow:
+#   1. A PR merges to develop with "Fixes #N" -> label issue N status:added-to-develop.
+#      GitHub's native keyword-close only fires on default-branch (master) merges, and
+#      it creates no link at all for develop-base PRs, so the body must be parsed.
+#   2. A release/* PR merges to master -> close every open issue carrying that label,
+#      since a develop->master release ships all of develop.
+#
+# SECURITY: pull_request_target is required so fork PRs get a write-capable token for
+# labeling. It is safe here because NOTHING from the PR head is checked out or executed
+# -- the PR body is only read as data inside github-script (never shell-interpolated).
+# The repo already uses this same pattern in label-conflicts.yml.
+name: Issue Lifecycle
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches:
+      - develop
+      - master
+
+permissions:
+  issues: write
+
+jobs:
+  label-added-to-develop:
+    name: Label linked issues on develop merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Upstream-only: the status label only exists on upstream's tracker.
+    if: >
+      github.repository == 'StuffAnThings/qbit_manage' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'develop'
+    steps:
+      - name: Add status:added-to-develop to issues this PR fixes
+        uses: actions/github-script@v9
+        with:
+          script: |
+            // Strip HTML comments so PR-template boilerplate ("Fixes # (issue)") can't match.
+            const body = (context.payload.pull_request.body || '').replace(/<!--[\s\S]*?-->/g, '');
+
+            // Official closing keywords; same-repo #N or full issue URL only.
+            const re = /\b(?:clos(?:e[sd]?)|fix(?:e[sd])?|resolv(?:e[sd]?))\s*:?\s+(?:https:\/\/github\.com\/StuffAnThings\/qbit_manage\/issues\/(\d+)|#(\d+))/gi;
+            const issues = new Set();
+            for (const m of body.matchAll(re)) issues.add(Number(m[1] || m[2]));
+
+            if (issues.size === 0) {
+              core.info('No closing-keyword issue references in PR body.');
+              return;
+            }
+
+            for (const issue_number of issues) {
+              try {
+                const { data: issue } = await github.rest.issues.get({ ...context.repo, issue_number });
+                if (issue.pull_request) { core.info(`#${issue_number} is a PR, skipping.`); continue; }
+                if (issue.state !== 'open') { core.info(`#${issue_number} already closed, skipping.`); continue; }
+                await github.rest.issues.addLabels({ ...context.repo, issue_number, labels: ['status:added-to-develop'] });
+                core.info(`Labeled #${issue_number}.`);
+              } catch (e) {
+                core.warning(`Skipping #${issue_number}: ${e.message}`);
+              }
+            }
+
+  close-released-issues:
+    name: Close shipped issues on release merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Gate on release/* head from the upstream repo itself: a fork PR titled
+    # release/x merged to master can never trigger a mass close.
+    if: >
+      github.repository == 'StuffAnThings/qbit_manage' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'master' &&
+      startsWith(github.event.pull_request.head.ref, 'release/') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Close all open issues labeled status:added-to-develop
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const version = context.payload.pull_request.head.ref.replace('release/', '');
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              ...context.repo, state: 'open', labels: 'status:added-to-develop', per_page: 100,
+            });
+
+            let closed = 0;
+            for (const issue of issues) {
+              if (issue.pull_request) continue;
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: issue.number,
+                body: `Released in [${version}](https://github.com/${context.repo.owner}/${context.repo.repo}/releases/tag/${version}). Closing — please open a new issue if this persists on the latest release.`,
+              });
+              await github.rest.issues.update({ ...context.repo, issue_number: issue.number, state: 'closed', state_reason: 'completed' });
+              core.info(`Closed #${issue.number}.`);
+              closed++;
+            }
+            core.info(`Closed ${closed} issue(s) for ${version}.`);


### PR DESCRIPTION
## Description

Adds `.github/workflows/issue-lifecycle.yml` to track issue status across the
`develop → master` release flow:

1. **PR merged to `develop`** with a closing keyword (`Fixes #N` / `Closes #N` /
   `Resolves #N`) → adds the existing `status:added-to-develop` label to issue N
   (does **not** close it — develop isn't production).
2. **`release/*` PR merged to `master`** → closes every open issue carrying
   `status:added-to-develop` with a "released in vX" comment, since a
   develop→master release ships all of develop.

### Why a workflow (not native / not a marketplace action)

GitHub's closing keywords only fire on merges to the **default branch** (master),
and it creates **no linked-issue reference at all** for `develop`-base PRs
(verified: merged PRs #1175/#1158 both return empty `closingIssuesReferences`).
No maintained marketplace action covers "label linked issues on merge to branch
X"; the only close-by-label actions are abandoned single-maintainer repos that
would run third-party code with `issues: write`. So this is one first-party
`actions/github-script@v9` file (already the repo's convention).

### Security

Uses `pull_request_target` (required so fork PRs get a write-capable token to
label issues) but **never checks out or executes PR-head code** — the PR body is
only read as data inside `github-script`. The close job is additionally gated on
an in-repo `release/*` head (`head.repo.full_name == github.repository`), so a
fork PR titled `release/x` can never trigger a mass close. Same pattern the repo
already uses in `label-conflicts.yml`.

### Verification

- Closing-keyword regex checked against real PR bodies (#1175 → `[1174]`, #1158 →
  `[1157]`), the PR template (→ `[]`, no false match on `Fixes # (issue)`), and
  edge cases (`resolves: #5 and closes #6` → `[5,6]`; bare `see #99` → `[]`).
- YAML + embedded JS syntax validated.

**Preview before first release:** the very first `release/* → master` merge will
close whatever is labeled at that time. Preview that set anytime with:
`gh issue list -R StuffAnThings/qbit_manage --label status:added-to-develop --state open`

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods (n/a — workflow only)
- [x] I have modified this PR to merge to the develop branch
