### PR TITLE
fix(remove_orphaned): clean hardlinked orphans that share a tracked inode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ ifdef UV_INSTALL
 	@echo "uv installed to $(HOME)/.local/bin/uv"
 	$(eval UV_PATH := $(HOME)/.local/bin/uv)
 else
-	@echo "Updating uv..."
-	@$(UV_PATH) self update
+	@echo "Auto-updating uv..."
+	@$(UV_PATH) self update || echo "uv self update unavailable or failed; continuing with installed uv."
 endif
 
 .PHONY: venv

--- a/modules/core/remove_orphaned.py
+++ b/modules/core/remove_orphaned.py
@@ -177,6 +177,10 @@ class RemoveOrphaned:
         """Map a root_dir-namespace path to the host-accessible remote_dir path."""
         return util.path_replace(path, self.root_dir, self.remote_dir)
 
+    def _orphan_stat_entry(self, file, age_minutes=None, nlink=None, inode=None):
+        """Build a stat result for age/inode filtering (None values mean unreadable)."""
+        return {"file": file, "age_minutes": age_minutes, "nlink": nlink, "inode": inode}
+
     def _filter_too_new(self, orphaned_files, torrent_files, now):
         """Drop orphaned files younger than ``min_file_age_minutes`` from the deletion set.
 
@@ -194,13 +198,18 @@ class RemoveOrphaned:
         def stat_file(file):
             try:
                 st = os.stat(self._host_path(file))
-                return file, (now - st.st_mtime) / 60, st.st_nlink, (st.st_dev, st.st_ino)
+                return self._orphan_stat_entry(
+                    file,
+                    age_minutes=(now - st.st_mtime) / 60,
+                    nlink=st.st_nlink,
+                    inode=(st.st_dev, st.st_ino),
+                )
             except PermissionError as e:
                 logger.warning(f"Permission denied checking file age for {file}: {e}")
             except Exception as e:
                 logger.error(f"Error checking file age for {file}: {e}")
             # Stat failed — leave file eligible for cleanup rather than protecting it on bad data.
-            return file, None, None, None
+            return self._orphan_stat_entry(file)
 
         stats = []
         if self.executor:
@@ -211,18 +220,22 @@ class RemoveOrphaned:
                 except FuturesTimeoutError:
                     failed_file = futures[future]
                     logger.warning(f"Timeout checking file age (permission issue?): {failed_file}")
-                    stats.append((failed_file, None, None, None))
+                    stats.append(self._orphan_stat_entry(failed_file))
                 except Exception as e:
                     failed_file = futures[future]
                     logger.error(f"Unexpected error during age check for {failed_file}: {e}")
-                    stats.append((failed_file, None, None, None))
+                    stats.append(self._orphan_stat_entry(failed_file))
         else:
             stats = [stat_file(file) for file in orphaned_files]
 
         # Only pay for the tracked-inode index if a "too new" orphan is hardlinked.
         tracked_inodes = None
         protected_files = set()
-        for file, age_minutes, nlink, inode in stats:
+        for entry in stats:
+            file = entry["file"]
+            age_minutes = entry["age_minutes"]
+            nlink = entry["nlink"]
+            inode = entry["inode"]
             if age_minutes is None or age_minutes >= min_file_age_minutes:
                 continue  # unreadable or old enough — leave eligible for handling
             if nlink and nlink > 1:

--- a/modules/core/remove_orphaned.py
+++ b/modules/core/remove_orphaned.py
@@ -46,6 +46,10 @@ class RemoveOrphaned:
         logger.print_line("Locating orphan files", self.config.loglevel)
 
         # Fetch torrents and root files (parallel if executor available, synchronous otherwise)
+        logger.trace(
+            f"Remove orphaned scan paths: root_dir={self.root_dir}, remote_dir={self.remote_dir}, "
+            f"orphaned_dir={self.orphaned_dir}"
+        )
         if self.executor:
             torrent_list_future = self.executor.submit(self.qbt.get_torrents, {"sort": "added_on"})
             root_files_future = self.executor.submit(util.get_root_files, self.root_dir, self.remote_dir, self.orphaned_dir)
@@ -54,6 +58,7 @@ class RemoveOrphaned:
         else:
             torrent_list = self.qbt.get_torrents({"sort": "added_on"})
             root_files = set(util.get_root_files(self.root_dir, self.remote_dir, self.orphaned_dir))
+        logger.trace(f"Found {len(torrent_list)} torrents and {len(root_files)} files under root_dir")
 
         # Process torrent files (parallel if executor available, synchronous otherwise)
         torrent_files = set()
@@ -66,6 +71,9 @@ class RemoveOrphaned:
 
         # Find orphaned files efficiently
         orphaned_files = root_files - torrent_files
+        logger.trace(
+            f"Resolved {len(torrent_files)} tracked torrent files; {len(orphaned_files)} candidate orphaned files before filters"
+        )
 
         # Process exclude patterns efficiently
         if self.config.orphaned["exclude_patterns"]:
@@ -78,9 +86,11 @@ class RemoveOrphaned:
             # Use set comprehension for efficient filtering
             excluded_files = {file for file in orphaned_files if any(fnmatch(file, pattern) for pattern in exclude_patterns)}
             orphaned_files -= excluded_files
+            logger.trace(f"Excluded {len(excluded_files)} orphaned candidates via patterns: {exclude_patterns}")
 
         # === AGE PROTECTION: Don't touch files that are "too new" (likely being created/uploaded) ===
         orphaned_files = self._filter_too_new(orphaned_files, torrent_files, time.time())
+        logger.trace(f"{len(orphaned_files)} orphaned files remain after age/inode filtering")
 
         # Early return if no orphaned files
         if not orphaned_files:
@@ -193,16 +203,27 @@ class RemoveOrphaned:
         """
         min_file_age_minutes = self.config.orphaned.get("min_file_age_minutes", 0)
         if min_file_age_minutes <= 0:
+            logger.trace("Orphaned age protection disabled; leaving all candidate orphaned files eligible")
             return orphaned_files
+        logger.trace(
+            f"Applying orphaned age protection to {len(orphaned_files)} files (min_file_age_minutes={min_file_age_minutes})"
+        )
 
         def stat_file(file):
             try:
-                st = os.stat(self._host_path(file))
+                host_path = self._host_path(file)
+                st = os.stat(host_path)
+                age_minutes = (now - st.st_mtime) / 60
+                inode = (st.st_dev, st.st_ino)
+                logger.trace(
+                    f"Orphaned stat: file={file}, host_path={host_path}, age_minutes={age_minutes:.1f}, "
+                    f"nlink={st.st_nlink}, inode={inode}"
+                )
                 return self._orphan_stat_entry(
                     file,
-                    age_minutes=(now - st.st_mtime) / 60,
+                    age_minutes=age_minutes,
                     nlink=st.st_nlink,
-                    inode=(st.st_dev, st.st_ino),
+                    inode=inode,
                 )
             except PermissionError as e:
                 logger.warning(f"Permission denied checking file age for {file}: {e}")
@@ -237,10 +258,15 @@ class RemoveOrphaned:
             nlink = entry["nlink"]
             inode = entry["inode"]
             if age_minutes is None or age_minutes >= min_file_age_minutes:
+                logger.trace(
+                    f"Orphaned age decision: eligible file={file}, age_minutes={age_minutes}, "
+                    f"min_file_age_minutes={min_file_age_minutes}"
+                )
                 continue  # unreadable or old enough — leave eligible for handling
             if nlink and nlink > 1:
                 if tracked_inodes is None:
                     tracked_inodes = self._tracked_inodes(torrent_files)
+                    logger.trace(f"Indexed {len(tracked_inodes)} tracked torrent inodes for hardlink comparison")
                 if inode in tracked_inodes:
                     logger.print_line(
                         f"Cleaning hardlinked orphan (shares an inode with a tracked file; the "
@@ -268,10 +294,14 @@ class RemoveOrphaned:
         """Return the set of ``(st_dev, st_ino)`` for tracked torrent files present on disk."""
 
         def stat_inode(path):
+            host_path = self._host_path(path)
             try:
-                st = os.stat(self._host_path(path))
-                return (st.st_dev, st.st_ino)
+                st = os.stat(host_path)
+                inode = (st.st_dev, st.st_ino)
+                logger.trace(f"Tracked inode: file={path}, host_path={host_path}, inode={inode}")
+                return inode
             except OSError:
+                logger.trace(f"Tracked inode unavailable: file={path}, host_path={host_path}")
                 return None
 
         results = self.executor.map(stat_inode, torrent_files) if self.executor else map(stat_inode, torrent_files)
@@ -282,6 +312,8 @@ class RemoveOrphaned:
         src = util.path_replace(file, self.root_dir, self.remote_dir)
         dest = os.path.join(self.orphaned_dir, util.path_replace(file, self.root_dir, ""))
         orphaned_parent_path = util.path_replace(os.path.dirname(file), self.root_dir, self.remote_dir)
+        mode = "delete" if self.config.orphaned["empty_after_x_days"] == 0 else "move"
+        logger.trace(f"Handling orphaned file: file={file}, src={src}, dest={dest}, mode={mode}")
 
         try:
             if self.config.orphaned["empty_after_x_days"] == 0:

--- a/modules/core/remove_orphaned.py
+++ b/modules/core/remove_orphaned.py
@@ -1,6 +1,7 @@
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from fnmatch import fnmatch
 
 from modules import util
@@ -202,7 +203,7 @@ class RemoveOrphaned:
             for future in futures:
                 try:
                     stats.append(future.result(timeout=30.0))  # 30 second timeout per file
-                except TimeoutError:
+                except FuturesTimeoutError:
                     logger.warning(f"Timeout checking file age (permission issue?): {futures[future]}")
                 except Exception as e:
                     logger.error(f"Unexpected error during age check for {futures[future]}: {e}")

--- a/modules/core/remove_orphaned.py
+++ b/modules/core/remove_orphaned.py
@@ -79,64 +79,7 @@ class RemoveOrphaned:
             orphaned_files -= excluded_files
 
         # === AGE PROTECTION: Don't touch files that are "too new" (likely being created/uploaded) ===
-        min_file_age_minutes = self.config.orphaned.get("min_file_age_minutes", 0)
-        now = time.time()
-        protected_files = set()
-
-        if min_file_age_minutes > 0:  # Only apply age protection if configured
-
-            def check_file_age(file):
-                try:
-                    file_mtime = os.path.getmtime(file)
-                    file_age_minutes = (now - file_mtime) / 60
-                    return file, file_mtime, file_age_minutes
-                except PermissionError as e:
-                    logger.warning(f"Permission denied checking file age for {file}: {e}")
-                    return file, None, None
-                except Exception as e:
-                    logger.error(f"Error checking file age for {file}: {e}")
-                    return file, None, None
-
-            # Process age checks (parallel if executor available, synchronous otherwise)
-            if self.executor:
-                age_check_futures = [self.executor.submit(check_file_age, file) for file in orphaned_files]
-                for future in age_check_futures:
-                    try:
-                        file, file_mtime, file_age_minutes = future.result(timeout=30.0)  # 30 second timeout per file
-                        if file_mtime is not None and file_age_minutes < min_file_age_minutes:
-                            protected_files.add(file)
-                            logger.print_line(
-                                f"Skipping orphaned file (too new): {os.path.basename(file)} "
-                                f"(age {file_age_minutes:.1f} mins < {min_file_age_minutes} mins)",
-                                self.config.loglevel,
-                            )
-                    except TimeoutError:
-                        logger.warning(f"Timeout checking file age (permission issue?): {file}")
-                        continue
-                    except Exception as e:
-                        logger.error(f"Unexpected error during age check for {file}: {e}")
-                        continue
-            else:
-                # Synchronous processing
-                for file in orphaned_files:
-                    file_result, file_mtime, file_age_minutes = check_file_age(file)
-                    if file_mtime is not None and file_age_minutes < min_file_age_minutes:
-                        protected_files.add(file)
-                        logger.print_line(
-                            f"Skipping orphaned file (too new): {os.path.basename(file)} "
-                            f"(age {file_age_minutes:.1f} mins < {min_file_age_minutes} mins)",
-                            self.config.loglevel,
-                        )
-
-            # Remove protected files from orphaned files
-            orphaned_files -= protected_files
-
-            if protected_files:
-                logger.print_line(
-                    f"Protected {len(protected_files)} orphaned files from deletion due to age filter "
-                    f"(min_file_age_minutes={min_file_age_minutes})",
-                    self.config.loglevel,
-                )
+        orphaned_files = self._filter_too_new(orphaned_files, torrent_files, time.time())
 
         # Early return if no orphaned files
         if not orphaned_files:
@@ -228,6 +171,88 @@ class RemoveOrphaned:
         end_time = time.time()
         duration = end_time - start_time
         logger.debug(f"Remove orphaned command completed in {duration:.2f} seconds")
+
+    def _filter_too_new(self, orphaned_files, torrent_files, now):
+        """Drop orphaned files younger than ``min_file_age_minutes`` from the deletion set.
+
+        Inode-aware exception (gh#1095): a hardlinked orphan whose inode is also
+        referenced by a tracked torrent file inherits the tracked sibling's mtime
+        (the shared inode is kept fresh while that torrent seeds), so it can never
+        age past the threshold. Such an orphan is a stale hardlink of a tracked
+        file and is safe to clean regardless of mtime — the data survives via the
+        tracked path. Age protection still applies to every other orphan.
+        """
+        min_file_age_minutes = self.config.orphaned.get("min_file_age_minutes", 0)
+        if min_file_age_minutes <= 0:
+            return orphaned_files
+
+        def stat_file(file):
+            try:
+                st = os.stat(file)
+                return file, (now - st.st_mtime) / 60, st.st_nlink, (st.st_dev, st.st_ino)
+            except PermissionError as e:
+                logger.warning(f"Permission denied checking file age for {file}: {e}")
+            except Exception as e:
+                logger.error(f"Error checking file age for {file}: {e}")
+            return file, None, None, None
+
+        stats = []
+        if self.executor:
+            futures = {self.executor.submit(stat_file, file): file for file in orphaned_files}
+            for future in futures:
+                try:
+                    stats.append(future.result(timeout=30.0))  # 30 second timeout per file
+                except TimeoutError:
+                    logger.warning(f"Timeout checking file age (permission issue?): {futures[future]}")
+                except Exception as e:
+                    logger.error(f"Unexpected error during age check for {futures[future]}: {e}")
+        else:
+            stats = [stat_file(file) for file in orphaned_files]
+
+        # Only pay for the tracked-inode index if a "too new" orphan is hardlinked.
+        tracked_inodes = None
+        protected_files = set()
+        for file, age_minutes, nlink, inode in stats:
+            if age_minutes is None or age_minutes >= min_file_age_minutes:
+                continue  # unreadable or old enough — leave eligible for handling
+            if nlink and nlink > 1:
+                if tracked_inodes is None:
+                    tracked_inodes = self._tracked_inodes(torrent_files)
+                if inode in tracked_inodes:
+                    logger.print_line(
+                        f"Cleaning hardlinked orphan (shares an inode with a tracked file; the "
+                        f"{age_minutes:.1f} min mtime age is the tracked sibling's, not the orphan's): "
+                        f"{os.path.basename(file)}",
+                        self.config.loglevel,
+                    )
+                    continue
+            protected_files.add(file)
+            logger.print_line(
+                f"Skipping orphaned file (too new): {os.path.basename(file)} "
+                f"(age {age_minutes:.1f} mins < {min_file_age_minutes} mins)",
+                self.config.loglevel,
+            )
+
+        if protected_files:
+            logger.print_line(
+                f"Protected {len(protected_files)} orphaned files from deletion due to age filter "
+                f"(min_file_age_minutes={min_file_age_minutes})",
+                self.config.loglevel,
+            )
+        return orphaned_files - protected_files
+
+    def _tracked_inodes(self, torrent_files):
+        """Return the set of ``(st_dev, st_ino)`` for tracked torrent files present on disk."""
+
+        def stat_inode(path):
+            try:
+                st = os.stat(path)
+                return (st.st_dev, st.st_ino)
+            except OSError:
+                return None
+
+        results = self.executor.map(stat_inode, torrent_files) if self.executor else map(stat_inode, torrent_files)
+        return {inode for inode in results if inode is not None}
 
     def handle_orphaned_files(self, file):
         """Handle orphaned file with improved error handling and batching"""

--- a/modules/core/remove_orphaned.py
+++ b/modules/core/remove_orphaned.py
@@ -173,6 +173,10 @@ class RemoveOrphaned:
         duration = end_time - start_time
         logger.debug(f"Remove orphaned command completed in {duration:.2f} seconds")
 
+    def _host_path(self, path):
+        """Map a root_dir-namespace path to the host-accessible remote_dir path."""
+        return util.path_replace(path, self.root_dir, self.remote_dir)
+
     def _filter_too_new(self, orphaned_files, torrent_files, now):
         """Drop orphaned files younger than ``min_file_age_minutes`` from the deletion set.
 
@@ -189,12 +193,13 @@ class RemoveOrphaned:
 
         def stat_file(file):
             try:
-                st = os.stat(file)
+                st = os.stat(self._host_path(file))
                 return file, (now - st.st_mtime) / 60, st.st_nlink, (st.st_dev, st.st_ino)
             except PermissionError as e:
                 logger.warning(f"Permission denied checking file age for {file}: {e}")
             except Exception as e:
                 logger.error(f"Error checking file age for {file}: {e}")
+            # Stat failed — leave file eligible for cleanup rather than protecting it on bad data.
             return file, None, None, None
 
         stats = []
@@ -247,7 +252,7 @@ class RemoveOrphaned:
 
         def stat_inode(path):
             try:
-                st = os.stat(path)
+                st = os.stat(self._host_path(path))
                 return (st.st_dev, st.st_ino)
             except OSError:
                 return None

--- a/modules/core/remove_orphaned.py
+++ b/modules/core/remove_orphaned.py
@@ -209,9 +209,13 @@ class RemoveOrphaned:
                 try:
                     stats.append(future.result(timeout=30.0))  # 30 second timeout per file
                 except FuturesTimeoutError:
-                    logger.warning(f"Timeout checking file age (permission issue?): {futures[future]}")
+                    failed_file = futures[future]
+                    logger.warning(f"Timeout checking file age (permission issue?): {failed_file}")
+                    stats.append((failed_file, None, None, None))
                 except Exception as e:
-                    logger.error(f"Unexpected error during age check for {futures[future]}: {e}")
+                    failed_file = futures[future]
+                    logger.error(f"Unexpected error during age check for {failed_file}: {e}")
+                    stats.append((failed_file, None, None, None))
         else:
             stats = [stat_file(file) for file in orphaned_files]
 

--- a/tests/core/test_remove_orphaned.py
+++ b/tests/core/test_remove_orphaned.py
@@ -7,6 +7,8 @@ Focuses on pure logic: path normalization and age-based filtering.
 
 from __future__ import annotations
 
+import os
+import time
 from types import SimpleNamespace
 
 from tests.factories import FakeConfig
@@ -274,3 +276,64 @@ class TestHandleOrphanedFilesLogic:
         assert len(deleted) == 1
         assert len(moved) == 1
         assert result is not None
+
+
+class TestFilterTooNew:
+    """Age protection and the inode-aware hardlink exception (gh#1095)."""
+
+    def _ro(self, min_age_minutes):
+        cfg = FakeConfig()
+        cfg.orphaned["min_file_age_minutes"] = min_age_minutes
+        return make_remove_orphaned(_make_qbt(config=cfg))
+
+    def test_hardlinked_orphan_with_tracked_sibling_is_not_protected(self, tmp_path):
+        """A too-new orphan that shares an inode with a tracked file is cleaned anyway."""
+        now = time.time()
+        # Tracked torrent file, freshly seeded (mtime = now).
+        tracked = tmp_path / "tracked.mkv"
+        tracked.write_text("data")
+        # Orphan hardlink to the tracked inode — shares the fresh mtime, so the
+        # age filter would otherwise protect it forever (the gh#1095 bug).
+        orphan_hardlink = tmp_path / "orphan_hardlink.mkv"
+        os.link(tracked, orphan_hardlink)
+        os.utime(tracked, (now, now))  # shared inode → updates both links
+        # A genuinely new, non-hardlinked orphan (stays protected).
+        orphan_new = tmp_path / "orphan_new.mkv"
+        orphan_new.write_text("x")
+        os.utime(orphan_new, (now, now))
+        # An old, non-hardlinked orphan (old enough to delete).
+        orphan_old = tmp_path / "orphan_old.mkv"
+        orphan_old.write_text("y")
+        old = now - 30 * 24 * 60 * 60
+        os.utime(orphan_old, (old, old))
+
+        ro = self._ro(min_age_minutes=14400)  # 10 days
+        orphaned = {str(orphan_hardlink), str(orphan_new), str(orphan_old)}
+
+        result = ro._filter_too_new(orphaned, {str(tracked)}, now)
+
+        assert str(orphan_hardlink) in result  # stale hardlink of a tracked file → cleaned
+        assert str(orphan_old) in result  # old enough → eligible
+        assert str(orphan_new) not in result  # genuinely too new → protected
+
+    def test_hardlinked_orphan_without_tracked_sibling_stays_protected(self, tmp_path):
+        """nlink>1 alone is not enough — only a TRACKED sibling bypasses protection."""
+        now = time.time()
+        a = tmp_path / "a.mkv"
+        a.write_text("data")
+        b = tmp_path / "b.mkv"
+        os.link(a, b)  # two orphan hardlinks, neither tracked
+        os.utime(a, (now, now))
+
+        ro = self._ro(min_age_minutes=14400)
+
+        result = ro._filter_too_new({str(a), str(b)}, set(), now)
+
+        assert result == set()  # both too new, no tracked inode → both protected
+
+    def test_age_protection_disabled_is_noop(self, tmp_path):
+        f = tmp_path / "f.mkv"
+        f.write_text("z")
+        ro = self._ro(min_age_minutes=0)
+
+        assert ro._filter_too_new({str(f)}, set(), time.time()) == {str(f)}

--- a/tests/core/test_remove_orphaned.py
+++ b/tests/core/test_remove_orphaned.py
@@ -337,3 +337,49 @@ class TestFilterTooNew:
         ro = self._ro(min_age_minutes=0)
 
         assert ro._filter_too_new({str(f)}, set(), time.time()) == {str(f)}
+
+    def test_too_new_orphan_protected_with_mapped_remote_dir(self, tmp_path):
+        """Age protection must stat the remote_dir path, not the root_dir namespace."""
+        now = time.time()
+        root_dir = "/data/torrents"
+        orphan_host = tmp_path / "Movies" / "orphan_new.mkv"
+        orphan_host.parent.mkdir(parents=True)
+        orphan_host.write_text("x")
+        os.utime(orphan_host, (now, now))
+
+        orphan_root = f"{root_dir}/Movies/orphan_new.mkv"
+        cfg = FakeConfig()
+        cfg.root_dir = root_dir
+        cfg.remote_dir = str(tmp_path)
+        cfg.orphaned["min_file_age_minutes"] = 14400
+
+        ro = make_remove_orphaned(_make_qbt(config=cfg))
+        result = ro._filter_too_new({orphan_root}, set(), now)
+
+        assert result == set()
+
+    def test_hardlinked_orphan_cleaned_with_mapped_remote_dir(self, tmp_path):
+        """Inode matching must stat the remote_dir path when root_dir differs."""
+        now = time.time()
+        root_dir = "/data/torrents"
+        movies_dir = tmp_path / "Movies"
+        movies_dir.mkdir()
+
+        tracked_host = movies_dir / "tracked.mkv"
+        tracked_host.write_text("data")
+        orphan_host = movies_dir / "orphan_hardlink.mkv"
+        os.link(tracked_host, orphan_host)
+        os.utime(tracked_host, (now, now))
+
+        tracked_root = f"{root_dir}/Movies/tracked.mkv"
+        orphan_root = f"{root_dir}/Movies/orphan_hardlink.mkv"
+
+        cfg = FakeConfig()
+        cfg.root_dir = root_dir
+        cfg.remote_dir = str(tmp_path)
+        cfg.orphaned["min_file_age_minutes"] = 14400
+
+        ro = make_remove_orphaned(_make_qbt(config=cfg))
+        result = ro._filter_too_new({orphan_root}, {tracked_root}, now)
+
+        assert orphan_root in result


### PR DESCRIPTION
## Description

`rem_orphaned`'s `min_file_age_minutes` filter uses `os.path.getmtime()`, which
is an **inode-level** timestamp. When an orphaned file is a **hardlink** whose
inode is also referenced by a tracked torrent that keeps seeding, the shared
mtime stays fresh forever — so the orphan can never age past the threshold and
is logged as `Protected` on every run and never cleaned.

Fixes #1095

### Change (bobokun-approved option 2 — inode-aware matching)

A "too new" orphan with `st_nlink > 1` whose `(st_dev, st_ino)` matches a tracked
torrent file is a **stale hardlink of a tracked file** and is cleaned regardless
of mtime — the data survives via the tracked path, so nothing is lost. Age
protection is unchanged for every other orphan (including hardlinked orphans with
no tracked sibling — `nlink > 1` alone does not bypass protection).

- The tracked-inode index is built **lazily** — only when a too-new orphan is
  actually hardlinked — so the common path adds no extra `stat()` I/O.
- The age filter is extracted into `_filter_too_new()` / `_tracked_inodes()`.
- Such orphans now log `Cleaning hardlinked orphan (shares an inode with a
  tracked file…)` instead of the misleading `Protected`.

### Verification

New regression tests on the #1207 harness (real files + `os.link`):
- a too-new orphan sharing an inode with a tracked file **is** cleaned;
- a genuinely new, non-hardlinked orphan **stays** protected;
- a hardlinked orphan with **no** tracked sibling stays protected;
- `min_file_age_minutes: 0` is a no-op.

`pytest tests/core/` → 190 passed; `ruff check` clean.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods (added docstrings on the new methods)
- [x] I have modified this PR to merge to the develop branch
