### PR TITLE
docs: develop is the default branch; checkout master for stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/bobokun/qbit_manage?label=docker&sort=semver&style=plastic)](https://hub.docker.com/r/bobokun/qbit_manage)
 [![PyPi (latest semver)](https://img.shields.io/pypi/v/qbit-manage?label=PyPI&sort=semver&style=plastic)](https://pypi.org/project/qbit-manage)
 [![Github Workflow Status](https://img.shields.io/github/actions/workflow/status/StuffAnThings/qbit_manage/version.yml?style=plastic)](https://github.com/StuffAnThings/qbit_manage/actions/workflows/version.yml)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/StuffAnThings/qbit_manage/master.svg)](https://results.pre-commit.ci/latest/github/StuffAnThings/qbit_manage/master)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/StuffAnThings/qbit_manage/develop.svg)](https://results.pre-commit.ci/latest/github/StuffAnThings/qbit_manage/develop)
 [![Ghcr packages](https://img.shields.io/badge/ghcr.io-packages?style=plastic&label=packages)](https://ghcr.io/StuffAnThings/qbit_manage)
 [![Docker Pulls](https://img.shields.io/docker/pulls/bobokun/qbit_manage?style=plastic)](https://hub.docker.com/r/bobokun/qbit_manage)
 [![Sponsor or Donate](https://img.shields.io/badge/-Sponsor_or_Donate-blueviolet?style=plastic)](https://github.com/sponsors/bobokun)

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -137,6 +137,10 @@ uv tool install qbit-manage
 git clone https://github.com/StuffAnThings/qbit_manage.git
 cd qbit_manage
 
+# The default branch is `develop` (latest code, may be unstable).
+# For the latest stable release, switch to master (omit to build from develop):
+git checkout master
+
 # Install uv if not already installed
 curl -LsSf https://astral.sh/uv/install.sh | sh
 


### PR DESCRIPTION
## Description

Documentation updates to accompany the repo default-branch change (`master` →
`develop`), landing in parallel with the repo-settings update:

- **Install from Source** (`docs/Installation.md`): note that the default branch
  is now `develop` (latest, may be unstable) and add `git checkout master` for
  the latest stable release.
- **README pre-commit.ci badge**: point at `develop` (the active/default branch).

Config-sample `blob/master/…` links are intentionally left as-is — they still
resolve and point to the stable sample. Docker image tags (`:latest` / `:develop`)
are independent of the GitHub default branch and are unchanged. PR-target
guidance already says `develop`, which stays correct.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (n/a — docs only)
- [ ] I have added or updated the docstring for new or existing methods (n/a — docs only)
- [x] I have modified this PR to merge to the develop branch
