### PR TITLE
ci: least-privilege GITHUB_TOKEN in version.yml + stop duplicate matrix on version bump

### DIFF
--- a/.github/workflows/bump-version-develop.yml
+++ b/.github/workflows/bump-version-develop.yml
@@ -68,5 +68,5 @@ jobs:
           git config user.name 'qbit-manage-bot'
           git config user.email 'qbit-manage-bot@users.noreply.github.com'
           git add VERSION
-          git commit -m "chore: bump VERSION to ${{ steps.bump.outputs.after }} [skip-version-bump]"
+          git commit -m "chore: bump VERSION to ${{ steps.bump.outputs.after }} [skip ci][skip-version-bump]"
           git push origin develop

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -13,6 +13,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default: docker-release only needs to read the repo.
+# publish-release overrides this at the job level with contents: write.
+permissions:
+  contents: read
+
 jobs:
   docker-release:
     runs-on: ubuntu-latest
@@ -22,7 +27,7 @@ jobs:
     steps:
       - name: set lower case owner name
         run: |
-          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+          echo "OWNER_LC=${OWNER,,}" >>"${GITHUB_ENV}"
         env:
           OWNER: "${{ github.repository_owner }}"
 
@@ -53,17 +58,17 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> "${GITHUB_OUTPUT}"
 
       - name: Read version from VERSION file
         id: get_app_version
-        run: echo "APP_VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
+        run: echo "APP_VERSION=$(cat VERSION)" >> "${GITHUB_OUTPUT}"
 
       - name: Set build metadata
         id: build_meta
         run: |
-          echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
-          echo "VCS_REF=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "${GITHUB_OUTPUT}"
+          echo "VCS_REF=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
 
       - name: Build and push
         id: docker_build
@@ -96,7 +101,7 @@ jobs:
     steps:
       - name: Get the version
         id: get_version
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> "${GITHUB_OUTPUT}"
 
       - name: Publish the draft release (keep its notes + assets)
         env:


### PR DESCRIPTION
## Description

Two low-risk CI hygiene fixes — workflow files only, no code changes.

### Fix 1 — `version.yml`: least-privilege GITHUB_TOKEN

The workflow had no `permissions:` block, so `docker-release` inherited the repo-default token (potentially write-all). The job only reads the repository and authenticates to Docker Hub / GHCR via its own repository secrets — it never needs `contents: write`.

Added a top-level `permissions: contents: read`. The `publish-release` job already declares `permissions: contents: write` at the job level, which overrides the workflow default for that job only; its behaviour is unchanged.

Also quoted `$GITHUB_OUTPUT` / `$GITHUB_ENV` in the same file (pre-existing SC2086 shellcheck findings; cleaned up opportunistically).

### Fix 2 — `bump-version-develop.yml`: stop the double 5-OS / 5-Python run

Every merge to `develop` triggers `bump-version-develop.yml`, which pushes a bot commit that changes only the `VERSION` file. Because `VERSION` is not in the `paths-ignore` of `develop.yml` or `tests.yml`, that bot commit fires the full 5-OS PyInstaller matrix and the 5-Python test matrix a second time — for a commit that contains zero logic changes.

Fix: append `[skip ci]` to the bump commit message. GitHub's native `[skip ci]` token suppresses all workflow runs for that push. The existing `[skip-version-bump]` guard in the job's `if:` condition is retained as defence-in-depth.

Trade-off vs. adding `VERSION` to `paths-ignore`: `[skip ci]` is a one-file, one-line change. A `paths-ignore` approach would require changes to two additional workflow files and would also suppress the Docker `:develop` image rebuild on any future VERSION-only commit (including manual version pins), which is a broader blast radius.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have modified this PR to merge to the develop branch
