### PR TITLE
fix(ci): chain develop builds after VERSION bump via workflow_run

### DIFF
--- a/.github/workflows/bump-version-develop.yml
+++ b/.github/workflows/bump-version-develop.yml
@@ -8,6 +8,8 @@ name: Bump Develop VERSION
 #
 # Skips itself: bump commits include `[skip-version-bump]` in the message,
 # so the job condition below will not re-run another bump.
+#
+# On completion, develop.yml chains automatically via workflow_run.
 
 on:
   push:
@@ -19,7 +21,6 @@ concurrency:
 
 permissions:
   contents: write
-  actions: write   # dispatch develop.yml after VERSION bump
 
 jobs:
   bump:
@@ -71,12 +72,3 @@ jobs:
           git add VERSION
           git commit -m "chore: bump VERSION to ${{ steps.bump.outputs.after }} [skip ci][skip-version-bump]"
           git push origin develop
-
-      # The bump commit carries `[skip ci]`, so develop.yml's `on: push` will not
-      # fire. Dispatch explicitly after VERSION is at its final value — same
-      # pattern as update-develop-branch.yml.
-      - name: Trigger develop workflow
-        if: success()
-        run: gh workflow run develop.yml --ref develop
-        env:
-          GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump-version-develop.yml
+++ b/.github/workflows/bump-version-develop.yml
@@ -19,6 +19,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: write   # dispatch develop.yml after VERSION bump
 
 jobs:
   bump:
@@ -70,3 +71,12 @@ jobs:
           git add VERSION
           git commit -m "chore: bump VERSION to ${{ steps.bump.outputs.after }} [skip ci][skip-version-bump]"
           git push origin develop
+
+      # The bump commit carries `[skip ci]`, so develop.yml's `on: push` will not
+      # fire. Dispatch explicitly after VERSION is at its final value — same
+      # pattern as update-develop-branch.yml.
+      - name: Trigger develop workflow
+        if: success()
+        run: gh workflow run develop.yml --ref develop
+        env:
+          GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -11,7 +11,7 @@ on:
       - "Bump Develop VERSION"
       - "Update Develop Branch"
     types: [completed]
-    branches: [develop]
+    branches: [develop, master]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,6 +1,9 @@
-# On every push to develop: build the binary + Tauri matrix (reusable workflow),
-# refresh the rolling `latest-develop` pre-release with those assets, and push the
-# `:develop` Docker image.
+# Build develop binaries + Docker `:develop` and refresh the rolling
+# `latest-develop` pre-release. Normally triggered by bump-version-develop.yml
+# (via workflow_dispatch) after VERSION is bumped — not on the merge commit
+# itself, which still carries the pre-bump VERSION. Also runs on workflow_dispatch
+# and on pushes whose commit message includes `[skip-version-bump]` (manual /
+# recovery paths that bypass the bump workflow).
 name: Docker Develop Release
 
 on:
@@ -28,7 +31,12 @@ jobs:
   build-release-assets:
     name: Build develop assets
     # Upstream-only: forks shouldn't burn ~5 OS-runners on every develop push.
-    if: github.repository == 'StuffAnThings/qbit_manage'
+    # Skip merge commits: bump-version-develop.yml dispatches this workflow once
+    # VERSION is bumped. workflow_dispatch covers that dispatch and manual runs.
+    if: >-
+      github.repository == 'StuffAnThings/qbit_manage' &&
+      (github.event_name == 'workflow_dispatch' ||
+       contains(github.event.head_commit.message, '[skip-version-bump]'))
     permissions:
       contents: read
       actions: write
@@ -40,7 +48,10 @@ jobs:
     name: Update rolling develop pre-release
     needs: build-release-assets
     # Upstream-only: rolling pre-release lives on the upstream repo.
-    if: github.repository == 'StuffAnThings/qbit_manage'
+    if: >-
+      github.repository == 'StuffAnThings/qbit_manage' &&
+      (github.event_name == 'workflow_dispatch' ||
+       contains(github.event.head_commit.message, '[skip-version-bump]'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -85,7 +96,10 @@ jobs:
   docker-develop:
     runs-on: ubuntu-latest
     # Upstream-only: DOCKER_HUB_USERNAME / GHCR_TOKEN aren't configured on forks.
-    if: github.repository == 'StuffAnThings/qbit_manage'
+    if: >-
+      github.repository == 'StuffAnThings/qbit_manage' &&
+      (github.event_name == 'workflow_dispatch' ||
+       contains(github.event.head_commit.message, '[skip-version-bump]'))
     permissions:
       contents: read
 

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,26 +1,17 @@
 # Build develop binaries + Docker `:develop` and refresh the rolling
-# `latest-develop` pre-release. Normally triggered by bump-version-develop.yml
-# (via workflow_dispatch) after VERSION is bumped — not on the merge commit
-# itself, which still carries the pre-bump VERSION. Also runs on workflow_dispatch
-# and on pushes whose commit message includes `[skip-version-bump]` (manual /
-# recovery paths that bypass the bump workflow).
+# `latest-develop` pre-release. Chains automatically after bump-version-develop.yml
+# (or update-develop-branch.yml) via workflow_run — always checks out the current
+# develop tip so the build includes the post-bump VERSION. workflow_dispatch remains
+# for manual recovery only.
 name: Docker Develop Release
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - "Bump Develop VERSION"
+      - "Update Develop Branch"
+    types: [completed]
     branches: [develop]
-    paths-ignore:
-      # Skip the full 5-OS PyInstaller + Tauri matrix on doc-only / template-only
-      # commits. Use workflow_dispatch to force a manual rebuild if a docs change
-      # needs to land in the bundled artifact.
-      - "docs/**"
-      - "**/*.md"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/FUNDING.yml"
-      - ".github/pull_request_template.md"
-      - ".github/labeler.yml"
-      - "CHANGELOG"
-      - "LICENSE"
   workflow_dispatch:
 
 concurrency:
@@ -31,18 +22,18 @@ jobs:
   build-release-assets:
     name: Build develop assets
     # Upstream-only: forks shouldn't burn ~5 OS-runners on every develop push.
-    # Skip merge commits: bump-version-develop.yml dispatches this workflow once
-    # VERSION is bumped. workflow_dispatch covers that dispatch and manual runs.
     if: >-
       github.repository == 'StuffAnThings/qbit_manage' &&
       (github.event_name == 'workflow_dispatch' ||
-       contains(github.event.head_commit.message, '[skip-version-bump]'))
+       github.event.workflow_run.conclusion == 'success')
     permissions:
       contents: read
       actions: write
     uses: ./.github/workflows/build-binaries.yml
     with:
-      ref: ${{ github.sha }}
+      # workflow_run.head_sha is the *triggering* commit (pre-bump merge); checkout
+      # the develop branch tip so we build after bump-version-develop.yml has pushed.
+      ref: develop
 
   develop-prerelease:
     name: Update rolling develop pre-release
@@ -51,15 +42,19 @@ jobs:
     if: >-
       github.repository == 'StuffAnThings/qbit_manage' &&
       (github.event_name == 'workflow_dispatch' ||
-       contains(github.event.head_commit.message, '[skip-version-bump]'))
+       github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Check Out develop commit
+      - name: Check Out develop tip
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.sha }}
+          ref: develop
+
+      - name: Record develop HEAD
+        id: head
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Download prepared release assets
         uses: actions/download-artifact@v8
@@ -74,6 +69,7 @@ jobs:
           set -euo pipefail
           VERSION="$(cat VERSION)"
           TAG="latest-develop"
+          HEAD_SHA="${{ steps.head.outputs.sha }}"
 
           # The GitHub API cannot move an existing tag to a new commit, so delete
           # the rolling release + its tag and recreate both at the current HEAD.
@@ -86,9 +82,9 @@ jobs:
             gh release delete "$TAG" --cleanup-tag --yes
           fi
           gh release create "$TAG" \
-            --target "${{ github.sha }}" \
+            --target "$HEAD_SHA" \
             --title "Develop build ($VERSION)" \
-            --notes "Rolling pre-release built from the latest \`develop\` commit (\`${{ github.sha }}\`). Auto-updated on every merge to develop — this is a development build, not a stable release." \
+            --notes "Rolling pre-release built from the latest \`develop\` commit (\`$HEAD_SHA\`). Auto-updated on every merge to develop — this is a development build, not a stable release." \
             --prerelease \
             --latest=false \
             release-assets/*
@@ -99,7 +95,7 @@ jobs:
     if: >-
       github.repository == 'StuffAnThings/qbit_manage' &&
       (github.event_name == 'workflow_dispatch' ||
-       contains(github.event.head_commit.message, '[skip-version-bump]'))
+       github.event.workflow_run.conclusion == 'success')
     permissions:
       contents: read
 
@@ -110,10 +106,10 @@ jobs:
         env:
           OWNER: "${{ github.repository_owner }}"
 
-      - name: Check Out Repo
+      - name: Check Out develop tip
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.sha }}
+          ref: develop
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4

--- a/.github/workflows/update-develop-branch.yml
+++ b/.github/workflows/update-develop-branch.yml
@@ -16,7 +16,6 @@ concurrency:
 
 permissions:
   contents: write
-  actions: write   # the final step dispatches develop.yml via `gh workflow run`
 
 jobs:
 
@@ -75,7 +74,7 @@ jobs:
           echo "$NEW_VERSION" > VERSION
           git add VERSION
           if ! git diff --cached --quiet; then
-            git commit -m "Update VERSION to $NEW_VERSION [skip ci]"
+            git commit -m "Update VERSION to $NEW_VERSION [skip ci][skip-version-bump]"
           else
             echo "VERSION already at $NEW_VERSION; nothing to commit"
           fi
@@ -90,15 +89,3 @@ jobs:
           fi
 
           echo "Successfully back-merged master and set develop to $NEW_VERSION"
-
-      # Unconditional dispatch is intentional: the VERSION-bump commit pushed above carries
-      # `[skip ci]`, which suppresses develop.yml's `on: push` trigger even under a PAT push.
-      # So we always dispatch it explicitly. (develop.yml has cancel-in-progress, so on the
-      # rare no-VERSION-change push a redundant auto-trigger would just be superseded.)
-      - name: Trigger develop workflow
-        if: success()
-        run: |
-          echo "Triggering develop workflow..."
-          gh workflow run develop.yml --ref develop
-        env:
-          GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -90,11 +90,11 @@ were already attached by `release-pr.yml` in Step 1).
 
 ### Rolling develop pre-release
 
-Every push to `develop` (excluding doc-only paths) triggers `bump-version-develop.yml`,
-which bumps `VERSION` and then dispatches `develop.yml`. The merge commit itself does
-**not** run `develop.yml` — it still carries the pre-bump `VERSION`, and the bump
-commit uses `[skip ci]`, so an explicit dispatch is required (same pattern as
-`update-develop-branch.yml`).
+Every push to `develop` triggers `bump-version-develop.yml`, which bumps `VERSION`
+when needed. When that workflow finishes, `develop.yml` chains automatically via
+`workflow_run` (same for `update-develop-branch.yml` after a master release).
+The develop build always checks out the current `develop` tip so binaries, Docker,
+and `latest-develop` match the bumped `VERSION`.
 
 `develop.yml` then:
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -78,7 +78,7 @@ and `pypi-publish.yml`. The cascade is two steps, not a single parallel burst:
 | `tag.yml` | Reads `VERSION`, creates and pushes the `v<X.Y.Z>` tag via `Kometa-Team/tag-new-version`. |
 | `pypi-publish.yml` | Triggered by the new `v*` tag; builds the Python package and publishes to PyPI via trusted publishing (OIDC, no API token needed). |
 | `version.yml` | Triggered by the `v*` tag; builds + pushes the Docker image, then publishes the draft GitHub release that `release-pr.yml` already prepared — flips it from draft to published. Does **not** rebuild binaries. |
-| `update-develop-branch.yml` | Resets `develop` to `master`, bumps `VERSION` to the next patch-develop1 (e.g. `4.7.3-develop1`), force-pushes develop, then triggers `develop.yml` to rebuild Docker develop images. |
+| `update-develop-branch.yml` | Back-merges `master` into `develop`, bumps `VERSION` to the next patch-develop1 (e.g. `4.7.3-develop1`); `develop.yml` chains automatically via `workflow_run`. |
 
 After `tag.yml` pushes the `v<X.Y.Z>` tag, `version.yml` fires: it builds and
 pushes the Docker image, then publishes the draft release (binaries and notes

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -90,7 +90,13 @@ were already attached by `release-pr.yml` in Step 1).
 
 ### Rolling develop pre-release
 
-Every push to `develop` (excluding doc-only paths) triggers `develop.yml`, which:
+Every push to `develop` (excluding doc-only paths) triggers `bump-version-develop.yml`,
+which bumps `VERSION` and then dispatches `develop.yml`. The merge commit itself does
+**not** run `develop.yml` — it still carries the pre-bump `VERSION`, and the bump
+commit uses `[skip ci]`, so an explicit dispatch is required (same pattern as
+`update-develop-branch.yml`).
+
+`develop.yml` then:
 
 1. Builds the full 5-platform binary + Tauri bundle matrix via `build-binaries.yml`.
 2. Pushes the `:develop` Docker image.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes a version mismatch in rolling `latest-develop` releases and `:develop` Docker images.

On every merge to `develop`, `develop.yml` was building from the merge commit (pre-bump `VERSION`) while `bump-version-develop.yml` then bumped `VERSION` with `[skip ci]`, so no rebuild ran — leaving artifacts one `-developN` behind.

**Fix:** `develop.yml` now chains **automatically** via `workflow_run` when `bump-version-develop.yml` or `update-develop-branch.yml` completes. It always checks out the `develop` branch tip (not `workflow_run.head_sha`, which is the pre-bump merge commit) so binaries, Docker, and `latest-develop` match the bumped `VERSION`.

No manual `gh workflow run` dispatch. `workflow_dispatch` on `develop.yml` remains for recovery only.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have modified this PR to merge to the develop branch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3807-85d0-7580-aa3a-3f84a1a03246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3807-85d0-7580-aa3a-3f84a1a03246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

