### PR TITLE
feat(ci): auto-close qBittorrent version-support issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -11,6 +11,13 @@ body:
       value: >
         **THIS IS NOT THE PLACE TO ASK FOR SUPPORT!**
         Please use [Notifiarr Discord](https://discord.com/invite/AURf8Yz) and post your question under the `qbit-manage` channel for support issues.
+  - type: markdown
+    attributes:
+      value: >
+        **Seeing "qbit_manage is only compatible with vX.Y.Z"?** That's not a bug — qBittorrent version support is
+        added automatically once [qbittorrent-api](https://pypi.org/project/qbittorrent-api/) adds it. No issue is
+        needed; see [Supported qBittorrent Versions](https://github.com/StuffAnThings/qbit_manage#supported-qbittorrent-versions).
+        Issues asking for this will be auto-closed.
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/2.feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature_request.yml
@@ -10,6 +10,12 @@ body:
     attributes:
       value: >
         Thanks for taking the time to file a feature request! Please fill out this form as completely as possible.
+  - type: markdown
+    attributes:
+      value: >
+        **Asking us to support a new qBittorrent version?** That's automated — no request needed. See
+        [Supported qBittorrent Versions](https://github.com/StuffAnThings/qbit_manage#supported-qbittorrent-versions).
+        Issues asking for this will be auto-closed.
   - type: textarea
     id: problem-relation
     attributes:

--- a/.github/workflows/auto-close-qbit-version-issues.yml
+++ b/.github/workflows/auto-close-qbit-version-issues.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.repository == 'StuffAnThings/qbit_manage'
     steps:
       - name: Detect and close
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const title = context.payload.issue.title || '';

--- a/.github/workflows/auto-close-qbit-version-issues.yml
+++ b/.github/workflows/auto-close-qbit-version-issues.yml
@@ -65,6 +65,11 @@ jobs:
                 'in the README), comment here and we\'ll reopen.',
             });
 
-            await github.rest.issues.addLabels({ ...context.repo, issue_number, labels: ['status:not-a-bug'] });
+            try {
+              await github.rest.issues.addLabels({ ...context.repo, issue_number, labels: ['status:not-a-bug'] });
+            } catch (e) {
+              core.warning(`Could not label #${issue_number}: ${e.message}`);
+            }
+
             await github.rest.issues.update({ ...context.repo, issue_number, state: 'closed', state_reason: 'not_planned' });
             core.info(`Auto-closed #${issue_number} as a qBittorrent version-support ask.`);

--- a/.github/workflows/auto-close-qbit-version-issues.yml
+++ b/.github/workflows/auto-close-qbit-version-issues.yml
@@ -1,0 +1,70 @@
+# Auto-closes issues asking for qBittorrent version support/compatibility bumps.
+#
+# The entire pipeline for this is already automated: Renovate auto-merges
+# qbittorrent-api updates (.github/renovate.json), which triggers
+# update-supported-versions.yml to open+automerge a PR updating
+# SUPPORTED_VERSIONS.json. No issue is ever actionable for this - opening one
+# just waits on qbittorrent-api upstream, same as everyone else.
+#
+# Matches on issue TITLE only (not body) to keep false positives near zero:
+#   - the literal error qbit_manage itself emits ("is only compatible with
+#     ... You are currently on ..."), see modules/qbittorrent.py
+#   - OR a version-support-style ask: a qBittorrent/qbit mention + a
+#     support/compat keyword + a version number, e.g. "[FR]: Support for
+#     qbittorrent 5.1.0", "[Bug]: Support qbit 4.5.5"
+name: Auto-close qBittorrent Version Issues
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  issues: write
+
+jobs:
+  auto-close:
+    name: Auto-close qBittorrent version-support issues
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Upstream-only: the status:not-a-bug label only exists on upstream's tracker.
+    if: github.repository == 'StuffAnThings/qbit_manage'
+    steps:
+      - name: Detect and close
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const title = context.payload.issue.title || '';
+
+            const compatError = /is only compatible with .* you are currently on/i;
+            const versionNum = /v?\d+\.\d+(?:\.\d+)?/;
+            const client = /\bqbittorrent\b|\bqbit\b/i;
+            const intent = /\bsupport(?:s|ing|ed)?\b|\bcompat(?:ible|ibility)?\b/i;
+
+            const isVersionSupportAsk =
+              compatError.test(title) ||
+              (versionNum.test(title) && client.test(title) && intent.test(title));
+
+            if (!isVersionSupportAsk) {
+              core.info('Title does not match the qBittorrent version-support pattern, skipping.');
+              return;
+            }
+
+            const issue_number = context.payload.issue.number;
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number,
+              body:
+                'This is expected and automated: qBittorrent version support is added automatically once ' +
+                '[qbittorrent-api](https://pypi.org/project/qbittorrent-api/) adds support for the new version, ' +
+                'picked up here by an automated dependency update + CI workflow. No issue or PR is needed to request this.\n\n' +
+                'See https://github.com/StuffAnThings/qbit_manage#supported-qbittorrent-versions for the currently ' +
+                'supported version ranges.\n\n' +
+                "If you're still hitting this after qbittorrent-api adds support for your version (check the badges " +
+                'in the README), comment here and we\'ll reopen.',
+            });
+
+            await github.rest.issues.addLabels({ ...context.repo, issue_number, labels: ['status:not-a-bug'] });
+            await github.rest.issues.update({ ...context.repo, issue_number, state: 'closed', state_reason: 'not_planned' });
+            core.info(`Auto-closed #${issue_number} as a qBittorrent version-support ask.`);

--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ We rely on [qbittorrent-api](https://pypi.org/project/qbittorrent-api/) to inter
 
 Generally expect new releases of qBittorrent to not immediately be supported. Support CANNOT be added until qbittorrent-api adds support for the version. Any material changed and impact must then be assessed prior to Qbit Manage supporting it.
 
-**Version bumps are automated — no issue or PR needed.** Once qbittorrent-api ships support for a new qBittorrent
-version, our dependency automation (Renovate) picks up the update and auto-merges it, which in turn triggers CI to
-update the supported-version badges below. Issues asking us to "add support for qBittorrent vX.Y" will be
-auto-closed and point back here; if qbit_manage still doesn't work on a version already shown as supported below,
-that's a real bug — please file one.
+**Version bumps are automated — no issue or PR needed.** [Renovate](https://docs.renovatebot.com/) watches
+`qbittorrent-api` on PyPI and always auto-merges its updates (major, minor, patch — see `.github/renovate.json`) as
+soon as a new release is 3+ days old. Each merge to `develop` then triggers CI
+(`update-supported-versions.yml`) to refresh `SUPPORTED_VERSIONS.json` and the badges below — the whole chain runs
+without a human touching it. Issues asking us to "add support for qBittorrent vX.Y" will be auto-closed and point
+back here; if qbit_manage still doesn't work on a version already shown as supported below, that's a real bug —
+please file one.
 
 ### Master
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Generally expect new releases of qBittorrent to not immediately be supported. Su
 
 **Version bumps are automated — no issue or PR needed.** [Renovate](https://docs.renovatebot.com/) watches
 `qbittorrent-api` on PyPI and always auto-merges its updates (major, minor, patch — see `.github/renovate.json`) as
-soon as a new release is 3+ days old. Each merge to `develop` then triggers CI
+soon as a new release is 3+ days old. Merging that bump changes `pyproject.toml`, which triggers CI
 (`update-supported-versions.yml`) to refresh `SUPPORTED_VERSIONS.json` and the badges below — the whole chain runs
 without a human touching it. Issues asking us to "add support for qBittorrent vX.Y" will be auto-closed and point
 back here; if qbit_manage still doesn't work on a version already shown as supported below, that's a real bug —

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ We rely on [qbittorrent-api](https://pypi.org/project/qbittorrent-api/) to inter
 
 Generally expect new releases of qBittorrent to not immediately be supported. Support CANNOT be added until qbittorrent-api adds support for the version. Any material changed and impact must then be assessed prior to Qbit Manage supporting it.
 
+**Version bumps are automated — no issue or PR needed.** Once qbittorrent-api ships support for a new qBittorrent
+version, our dependency automation (Renovate) picks up the update and auto-merges it, which in turn triggers CI to
+update the supported-version badges below. Issues asking us to "add support for qBittorrent vX.Y" will be
+auto-closed and point back here; if qbit_manage still doesn't work on a version already shown as supported below,
+that's a real bug — please file one.
+
 ### Master
 
 ![master - qBittorrent version](https://img.shields.io/badge/dynamic/json?label=master%20-%20qBittorrent&query=master.qbit&url=https%3A%2F%2Fraw.githubusercontent.com%2FStuffAnThings%2Fqbit_manage%2Fdevelop%2FSUPPORTED_VERSIONS.json&color=brightgreen)


### PR DESCRIPTION
## Summary
- Add a workflow (`auto-close-qbit-version-issues.yml`) that auto-closes issues asking us to support a new qBittorrent version — the whole bump pipeline (Renovate auto-merge of `qbittorrent-api` → `update-supported-versions.yml` auto-PR) already handles this with zero human action, so these issues were pure noise being closed by hand (e.g. #1297, #1274).
- Matches on issue **title only**: the app's own compat-check error string (`is only compatible with ... You are currently on ...`), OR a support/compat keyword + qBittorrent/qbit mention + a version number (catches `[FR]: Support for qbittorrent 5.1.0`-style asks too). Verified against 7 known matching titles and 10 known non-matching titles from issue history — zero false positives/negatives against that set.
- Closes with the same comment style used manually, `state_reason: not_planned`, and adds `status:not-a-bug` for auditability. Invites reopening if the problem persists after qbittorrent-api actually ships support.
- Flags this upfront in both `1.bug_report.yml` and `2.feature_request.yml`, and clarifies in the README's "Supported qBittorrent Versions" section that bumps are automated and need no issue/PR.

## Test plan
- [x] `pre-commit run` passes on all touched files (yaml checks, trailing whitespace, etc.)
- [x] YAML syntax validated for the new workflow + both templates
- [x] Regex logic verified in isolation against real historical issue titles (7 must-match / 10 must-not-match, all correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
