### PR TITLE
chore(renovate): only rebase PRs on real conflicts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,7 @@
         "develop"
     ],
     "platformAutomerge": true,
+    "rebaseWhen": "conflicted",
     "minimumReleaseAge": "3 days",
     "labels": [
         "dependencies"


### PR DESCRIPTION
## Summary
- Sets `rebaseWhen: "conflicted"` in `.github/renovate.json`. Currently unset (defaults to `"auto"`), which rebases every Renovate PR any time it falls behind `develop` — re-triggering CI on every unrelated merge to `develop`. Pinning to `conflicted` limits rebases to PRs that actually have a merge conflict.

## Test plan
- [x] `python -m json.tool` / pre-commit `check json` pass
- [ ] Config-only change, verified live by watching the next few Renovate runs after merge — no rebase noise on PRs that aren't conflicted

🤖 Generated with [Claude Code](https://claude.com/claude-code)