### PR TITLE
ci: skip develop VERSION bump on GitHub-Actions-only pushes

### DIFF
--- a/.github/workflows/bump-version-develop.yml
+++ b/.github/workflows/bump-version-develop.yml
@@ -6,6 +6,9 @@ name: Bump Develop VERSION
 # contributor PRs no longer carry VERSION bumps and stop hitting rebase
 # conflicts on VERSION.
 #
+# Skips pushes that only touch .github/** (CI/workflow/Renovate-only changes) -
+# no app code changed, so no version bump or downstream Docker rebuild is needed.
+#
 # Skips itself: bump commits include `[skip-version-bump]` in the message,
 # so the job condition below will not re-run another bump.
 #
@@ -14,6 +17,8 @@ name: Bump Develop VERSION
 on:
   push:
     branches: [develop]
+    paths-ignore:
+      - ".github/**"
 
 concurrency:
   group: bump-version-develop


### PR DESCRIPTION
## Summary
- Adds `paths-ignore: [".github/**"]` to `Bump Develop VERSION`'s push trigger. Renovate is now active (see #1298-#1302) and will regularly push GitHub-Actions/config-only bumps to `develop` — none of those touch app code, so bumping `-developN` and rebuilding the `:develop` Docker image for each one is pure noise.
- `develop.yml` (Docker build) chains via `workflow_run` off this workflow completing, so it correctly stays skipped too when the bump is skipped — no extra wiring needed.
- Mixed pushes (app code + `.github/` changes together) still bump normally, since `paths-ignore` only skips a run when *every* changed file matches.

## Test plan
- [x] YAML validated, pre-commit passes
- [ ] Live verification: next Renovate GitHub-Actions-only PR merge to develop should NOT produce a `chore: bump VERSION to ...` commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)