### PR TITLE
fix(renovate): don't auto-merge minor bumps on 0.x packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -133,6 +133,20 @@
             "automerge": false
         },
         {
+            "description": "0.x packages: a minor bump can be as breaking as a major one (pre-1.0 semver gives no compat guarantee). Pull these out of the auto-merged python-deps/cargo-deps groups into their own reviewed group, placed after those rules so it overrides their inherited automerge.",
+            "matchManagers": [
+                "pep621",
+                "cargo"
+            ],
+            "matchCurrentVersion": "<1.0.0",
+            "matchUpdateTypes": [
+                "minor"
+            ],
+            "groupName": "Unstable (0.x) minor updates",
+            "groupSlug": "unstable-0x-minor",
+            "automerge": false
+        },
+        {
             "description": "Keep salsify/action-detect-and-tag-new-version pinned (matches prior Dependabot ignore)",
             "matchDepNames": [
                 "salsify/action-detect-and-tag-new-version"


### PR DESCRIPTION
## Summary
- `python-deps` and `cargo-deps` packageRules group `minor+patch+pin+digest` together and inherit automerge from the `extends` presets. For a 0.x package, a "minor" bump has no semver compat guarantee — this isn't hypothetical: #1304 bundled `reqwest` 0.11→0.13 with 11 unrelated safe patch bumps, and its lockfile resolution is failing (retried, still fails — not transient).
- Adds a packageRule matching `matchCurrentVersion: "<1.0.0"` + `matchUpdateTypes: ["minor"]` across `pep621`/`cargo`, grouped separately with `automerge: false`, placed after the existing groups so it overrides their inherited automerge for just this intersection.
- Currently affects 5 Python 0.x deps (`fastapi`, `ruamel.yaml`, `slowapi`, `uvicorn`, `ruff` — `fastapi`/`uvicorn` back the web API) and 5 Cargo 0.x deps (`reqwest`, `glib`, `libc`, `windows`, `toml`).

## Test plan
- [x] `renovate-config-validator` passes
- [x] `pre-commit` (json check, formatting) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
