### PR TITLE
fix(desktop): windows crate 0.62 Option<u32> for reserved registry params

### DIFF
--- a/desktop/tauri/src-tauri/src/main.rs
+++ b/desktop/tauri/src-tauri/src/main.rs
@@ -115,7 +115,7 @@ fn save_minimize_setting(app: &AppHandle, value: bool) {
 fn is_startup_enabled() -> bool {
   unsafe {
     let mut hkey = HKEY::default();
-    if RegOpenKeyExW(HKEY_CURRENT_USER, w!("Software\\Microsoft\\Windows\\CurrentVersion\\Run"), Some(0), KEY_READ, &mut hkey).is_ok() {
+    if RegOpenKeyExW(HKEY_CURRENT_USER, w!("Software\\Microsoft\\Windows\\CurrentVersion\\Run"), None, KEY_READ, &mut hkey).is_ok() {
       let mut buffer = [0u16; 260];
       let mut size = (buffer.len() * 2) as u32;
       let result = RegQueryValueExW(hkey, w!("qbit-manage-desktop"), None, None, Some(buffer.as_mut_ptr() as *mut _), Some(&mut size));
@@ -131,13 +131,13 @@ fn is_startup_enabled() -> bool {
 fn set_startup_enabled(enabled: bool) {
   unsafe {
     let mut hkey = HKEY::default();
-    if RegOpenKeyExW(HKEY_CURRENT_USER, w!("Software\\Microsoft\\Windows\\CurrentVersion\\Run"), Some(0), KEY_SET_VALUE, &mut hkey).is_ok() {
+    if RegOpenKeyExW(HKEY_CURRENT_USER, w!("Software\\Microsoft\\Windows\\CurrentVersion\\Run"), None, KEY_SET_VALUE, &mut hkey).is_ok() {
       if enabled {
         if let Ok(exe_path) = std::env::current_exe() {
           if let Some(path_str) = exe_path.to_str() {
             let wide_path: Vec<u16> = path_str.encode_utf16().chain(std::iter::once(0)).collect();
             let data_bytes = std::slice::from_raw_parts(wide_path.as_ptr() as *const u8, wide_path.len() * 2);
-            let _ = RegSetValueExW(hkey, w!("qbit-manage-desktop"), Some(0), REG_SZ, Some(data_bytes));
+            let _ = RegSetValueExW(hkey, w!("qbit-manage-desktop"), None, REG_SZ, Some(data_bytes));
           }
         }
       } else {

--- a/desktop/tauri/src-tauri/src/main.rs
+++ b/desktop/tauri/src-tauri/src/main.rs
@@ -115,7 +115,7 @@ fn save_minimize_setting(app: &AppHandle, value: bool) {
 fn is_startup_enabled() -> bool {
   unsafe {
     let mut hkey = HKEY::default();
-    if RegOpenKeyExW(HKEY_CURRENT_USER, w!("Software\\Microsoft\\Windows\\CurrentVersion\\Run"), 0, KEY_READ, &mut hkey).is_ok() {
+    if RegOpenKeyExW(HKEY_CURRENT_USER, w!("Software\\Microsoft\\Windows\\CurrentVersion\\Run"), Some(0), KEY_READ, &mut hkey).is_ok() {
       let mut buffer = [0u16; 260];
       let mut size = (buffer.len() * 2) as u32;
       let result = RegQueryValueExW(hkey, w!("qbit-manage-desktop"), None, None, Some(buffer.as_mut_ptr() as *mut _), Some(&mut size));
@@ -131,13 +131,13 @@ fn is_startup_enabled() -> bool {
 fn set_startup_enabled(enabled: bool) {
   unsafe {
     let mut hkey = HKEY::default();
-    if RegOpenKeyExW(HKEY_CURRENT_USER, w!("Software\\Microsoft\\Windows\\CurrentVersion\\Run"), 0, KEY_SET_VALUE, &mut hkey).is_ok() {
+    if RegOpenKeyExW(HKEY_CURRENT_USER, w!("Software\\Microsoft\\Windows\\CurrentVersion\\Run"), Some(0), KEY_SET_VALUE, &mut hkey).is_ok() {
       if enabled {
         if let Ok(exe_path) = std::env::current_exe() {
           if let Some(path_str) = exe_path.to_str() {
             let wide_path: Vec<u16> = path_str.encode_utf16().chain(std::iter::once(0)).collect();
             let data_bytes = std::slice::from_raw_parts(wide_path.as_ptr() as *const u8, wide_path.len() * 2);
-            let _ = RegSetValueExW(hkey, w!("qbit-manage-desktop"), 0, REG_SZ, Some(data_bytes));
+            let _ = RegSetValueExW(hkey, w!("qbit-manage-desktop"), Some(0), REG_SZ, Some(data_bytes));
           }
         }
       } else {


### PR DESCRIPTION
## Summary
\`Docker Develop Release\` is failing on the Windows build (job https://github.com/StuffAnThings/qbit_manage/actions/runs/29165211328) after #1304 bumped \`windows\` 0.58→0.62 — a second breaking 0.x-minor change from that PR, same root cause pattern as #1312's reqwest/rustls-tls fix: \`RegOpenKeyExW\`/\`RegSetValueExW\`'s reserved/\`ulOptions\` parameter changed from a bare integer to \`Option<u32>\` in this crate version.

Confirmed against the actual \`windows-rs\` 0.62.2 source (not just the one call rustc showed inline for \`RegSetValueExW\` — pulled \`RegOpenKeyExW\`'s real signature too, since only \`RegSetValueExW\`'s error had the full compiler suggestion in the log):

\`\`\`rust
pub unsafe fn RegOpenKeyExW<P1>(hkey: HKEY, lpsubkey: P1, uloptions: Option<u32>, samdesired: REG_SAM_FLAGS, phkresult: *mut HKEY) -> WIN32_ERROR
\`\`\`

3 call sites fixed: 2× \`RegOpenKeyExW\` (\`is_startup_enabled\`, \`set_startup_enabled\`), 1× \`RegSetValueExW\`.

4/5 platforms (both Linux runners, both macOS runners) already build clean on \`develop\` — this is Windows-registry-code-only and unrelated to the earlier Cargo.lock/reqwest issue.

## Test plan
- [x] Confirmed \`RegOpenKeyExW\`'s real 0.62.2 signature from the windows-rs source (fetched via a throwaway probe crate), not assumed by pattern-matching
- [x] pre-commit passes
- Full Windows cross-compile wasn't run locally (no MSVC toolchain available in this environment) — CI's Windows runner will confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)