### PR TITLE
ci: harden GitHub release API handling

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -19,8 +19,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  resolve-develop:
+    name: Resolve develop commit
+    if: >-
+      github.repository == 'StuffAnThings/qbit_manage' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      sha: ${{ steps.head.outputs.sha }}
+    steps:
+      - name: Check Out develop tip
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: develop
+
+      - name: Record develop HEAD
+        id: head
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
   build-release-assets:
     name: Build develop assets
+    needs: resolve-develop
     # Upstream-only: forks shouldn't burn ~5 OS-runners on every develop push.
     if: >-
       github.repository == 'StuffAnThings/qbit_manage' &&
@@ -31,13 +53,11 @@ jobs:
       actions: write
     uses: ./.github/workflows/build-binaries.yml
     with:
-      # workflow_run.head_sha is the *triggering* commit (pre-bump merge); checkout
-      # the develop branch tip so we build after bump-version-develop.yml has pushed.
-      ref: develop
+      ref: ${{ needs.resolve-develop.outputs.sha }}
 
   develop-prerelease:
     name: Update rolling develop pre-release
-    needs: build-release-assets
+    needs: [resolve-develop, build-release-assets]
     # Upstream-only: rolling pre-release lives on the upstream repo.
     if: >-
       github.repository == 'StuffAnThings/qbit_manage' &&
@@ -50,11 +70,7 @@ jobs:
       - name: Check Out develop tip
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: develop
-
-      - name: Record develop HEAD
-        id: head
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          ref: ${{ needs.resolve-develop.outputs.sha }}
 
       - name: Download prepared release assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -69,7 +85,7 @@ jobs:
           set -euo pipefail
           VERSION="$(cat VERSION)"
           TAG="latest-develop"
-          HEAD_SHA="${{ steps.head.outputs.sha }}"
+          HEAD_SHA="${{ needs.resolve-develop.outputs.sha }}"
           RELEASE_ERROR="$(mktemp)"
           trap 'rm -f "$RELEASE_ERROR"' EXIT
 
@@ -97,6 +113,7 @@ jobs:
             release-assets/*
 
   docker-develop:
+    needs: resolve-develop
     runs-on: ubuntu-latest
     # Upstream-only: DOCKER_HUB_USERNAME / GHCR_TOKEN aren't configured on forks.
     if: >-
@@ -109,14 +126,14 @@ jobs:
     steps:
       - name: set lower case owner name
         run: |
-          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+          echo "OWNER_LC=${OWNER,,}" >>"${GITHUB_ENV}"
         env:
           OWNER: "${{ github.repository_owner }}"
 
       - name: Check Out develop tip
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: develop
+          ref: ${{ needs.resolve-develop.outputs.sha }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
@@ -142,13 +159,13 @@ jobs:
 
       - name: Read version from VERSION file
         id: get_version
-        run: echo "APP_VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
+        run: echo "APP_VERSION=$(cat VERSION)" >> "$GITHUB_OUTPUT"
 
       - name: Set build metadata
         id: build_meta
         run: |
-          echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
-          echo "VCS_REF=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          echo "VCS_REF=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         id: docker_build

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -67,7 +67,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Check Out develop tip
+      - name: Check out pinned develop SHA
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ needs.resolve-develop.outputs.sha }}
@@ -130,7 +130,7 @@ jobs:
         env:
           OWNER: "${{ github.repository_owner }}"
 
-      - name: Check Out develop tip
+      - name: Check out pinned develop SHA
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ needs.resolve-develop.outputs.sha }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -15,8 +15,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: develop-release
+  cancel-in-progress: false
 
 jobs:
   build-release-assets:
@@ -70,16 +70,23 @@ jobs:
           VERSION="$(cat VERSION)"
           TAG="latest-develop"
           HEAD_SHA="${{ steps.head.outputs.sha }}"
+          RELEASE_ERROR="$(mktemp)"
+          trap 'rm -f "$RELEASE_ERROR"' EXIT
 
           # The GitHub API cannot move an existing tag to a new commit, so delete
           # the rolling release + its tag and recreate both at the current HEAD.
           # This keeps a single, always-current develop pre-release instead of one
           # per merge. The tag is intentionally non-`v*` so it never trips
           # tag.yml / version.yml / pypi-publish.yml.
-          # Delete only when it exists, so a real auth/permission error surfaces
-          # instead of being masked by `|| true`.
-          if gh release view "$TAG" >/dev/null 2>&1; then
+          # Only a missing release may skip deletion. Authentication, rate-limit,
+          # and transient API failures must stop the job with their original error.
+          if gh release view "$TAG" >/dev/null 2>"$RELEASE_ERROR"; then
             gh release delete "$TAG" --cleanup-tag --yes
+          elif grep -Eq 'release not found|HTTP 404' "$RELEASE_ERROR"; then
+            :
+          else
+            cat "$RELEASE_ERROR" >&2
+            exit 1
           fi
           gh release create "$TAG" \
             --target "$HEAD_SHA" \

--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -17,7 +17,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: label-conflicts-${{ github.ref }}
+  # pull_request_target uses the base branch for github.ref, so use the PR
+  # number to avoid unrelated PRs cancelling one another's conflict check.
+  group: label-conflicts-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -227,8 +227,19 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           TAG: "v${{ needs.prepare-release-branch.outputs.new_version }}"
         run: |
-          if gh release view "$TAG" --json isDraft -q '.isDraft' 2>/dev/null | grep -qx 'false'; then
-            echo "::error::Release $TAG already exists and is published. Delete it before re-running."
+          set -euo pipefail
+          RELEASE_ERROR="$(mktemp)"
+          trap 'rm -f "$RELEASE_ERROR"' EXIT
+
+          if RELEASE_IS_DRAFT="$(gh release view "$TAG" --json isDraft -q '.isDraft' 2>"$RELEASE_ERROR")"; then
+            if [[ "$RELEASE_IS_DRAFT" == "false" ]]; then
+              echo "::error::Release $TAG already exists and is published. Delete it before re-running."
+              exit 1
+            fi
+          elif grep -Eq 'release not found|HTTP 404' "$RELEASE_ERROR"; then
+            :
+          else
+            cat "$RELEASE_ERROR" >&2
             exit 1
           fi
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -10,8 +10,8 @@ on:
       - v*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: production-release-${{ github.ref }}
+  cancel-in-progress: false
 
 # Least-privilege default: docker-release only needs to read the repo.
 # publish-release overrides this at the job level with contents: write.
@@ -108,13 +108,20 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
           TAG="${{ steps.get_version.outputs.VERSION }}"
+          RELEASE_ERROR="$(mktemp)"
+          trap 'rm -f "$RELEASE_ERROR"' EXIT
 
           # release-pr.yml created this draft with the standalone binaries +
           # auto-generated changelog already attached. Just flip it to published;
           # do NOT touch the body or assets.
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            echo "::error::No release found for tag $TAG — expected a draft created by release-pr.yml."
+          if ! gh release view "$TAG" >/dev/null 2>"$RELEASE_ERROR"; then
+            if grep -Eq 'release not found|HTTP 404' "$RELEASE_ERROR"; then
+              echo "::error::No release found for tag $TAG; expected a draft created by release-pr.yml."
+            else
+              cat "$RELEASE_ERROR" >&2
+            fi
             exit 1
           fi
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -10,7 +10,7 @@ on:
       - v*
 
 concurrency:
-  group: production-release-${{ github.ref }}
+  group: production-release
   cancel-in-progress: false
 
 # Least-privilege default: docker-release only needs to read the repo.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -84,6 +84,13 @@ After `tag.yml` pushes the `v<X.Y.Z>` tag, `version.yml` fires: it builds and
 pushes the Docker image, then publishes the draft release (binaries and notes
 were already attached by `release-pr.yml` in Step 1).
 
+Production release runs queue per version tag instead of cancelling in progress.
+Both the pre-merge published-release guard in `release-pr.yml` and the post-merge
+draft lookup in `version.yml` distinguish an explicit not-found response from
+authentication, rate-limit, and transient GitHub API failures. Unexpected API
+failures stop with their original message instead of being reported as a missing
+release or allowing a published release to reach the draft-update action.
+
 ---
 
 ## Develop Builds & PR Artifacts

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -104,6 +104,15 @@ and `latest-develop` match the bumped `VERSION`.
    current develop HEAD (`gh release delete latest-develop --cleanup-tag`, then
    `gh release create latest-develop --prerelease --latest=false ...`).
 
+All develop-release runs share the fixed `develop-release` concurrency group and
+queue instead of cancelling in progress. This prevents two runs from deleting or
+creating the rolling release at the same time, and avoids cancellation between the
+delete and create operations. Before deletion, the workflow checks whether the
+release exists. Only an explicit not-found response skips deletion; authentication,
+rate-limit, and transient GitHub API failures stop the job with the original error.
+This distinction prevents an API outage from being misread as an absent release and
+then reported misleadingly as a duplicate-tag failure during creation.
+
 The `latest-develop` tag is intentionally non-`v*` so it never triggers `tag.yml`,
 `version.yml`, or `pypi-publish.yml`. Use it to grab a development binary without
 waiting for a full release.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -84,12 +84,14 @@ After `tag.yml` pushes the `v<X.Y.Z>` tag, `version.yml` fires: it builds and
 pushes the Docker image, then publishes the draft release (binaries and notes
 were already attached by `release-pr.yml` in Step 1).
 
-Production release runs queue per version tag instead of cancelling in progress.
-Both the pre-merge published-release guard in `release-pr.yml` and the post-merge
-draft lookup in `version.yml` distinguish an explicit not-found response from
-authentication, rate-limit, and transient GitHub API failures. Unexpected API
-failures stop with their original message instead of being reported as a missing
-release or allowing a published release to reach the draft-update action.
+All production release runs share the fixed `production-release` concurrency
+group and queue instead of cancelling in progress, serializing every release
+run regardless of version tag. Both the pre-merge published-release guard in
+`release-pr.yml` and the post-merge draft lookup in `version.yml` distinguish
+an explicit not-found response from authentication, rate-limit, and transient
+GitHub API failures. Unexpected API failures stop with their original message
+instead of being reported as a missing release or allowing a published
+release to reach the draft-update action.
 
 ---
 

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -181,6 +181,22 @@ chore(deps): bump ruff from 0.14.5 to 0.14.6
 For the release process (merging `develop → master`, tagging, PyPI publish),
 see [`DEVELOPER.md`](../DEVELOPER.md).
 
+### Release workflow changes
+
+Changes to `.github/workflows/develop.yml` must preserve the rolling develop
+release invariants:
+
+- All runs use the fixed `develop-release` concurrency group and queue rather
+  than cancel in progress. The workflow must not be interrupted between deleting
+  and recreating `latest-develop`.
+- The rolling release and its tag are deleted together, then recreated at the
+  current `develop` HEAD with the prepared build assets.
+- Only an explicit not-found response may skip deletion. Authentication,
+  rate-limit, and transient GitHub API errors must fail with their original
+  message instead of being treated as a missing release.
+- The `latest-develop` tag remains non-`v*` so it cannot trigger stable-release
+  workflows.
+
 ---
 
 ## Project Structure

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -196,6 +196,10 @@ release invariants:
   message instead of being treated as a missing release.
 - The `latest-develop` tag remains non-`v*` so it cannot trigger stable-release
   workflows.
+- Production release changes must preserve API errors in both the pre-merge draft
+  guard (`release-pr.yml`) and the post-merge publisher (`version.yml`). Only an
+  explicit not-found response may be handled as an absent release, and publication
+  runs for the same version tag must queue instead of cancelling in progress.
 
 ---
 

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -198,8 +198,10 @@ release invariants:
   workflows.
 - Production release changes must preserve API errors in both the pre-merge draft
   guard (`release-pr.yml`) and the post-merge publisher (`version.yml`). Only an
-  explicit not-found response may be handled as an absent release, and publication
-  runs for the same version tag must queue instead of cancelling in progress.
+  explicit not-found response may be handled as an absent release, and all
+  publication runs must share the fixed `production-release` concurrency group
+  and queue instead of cancelling in progress, serializing every run regardless
+  of version tag.
 
 ---
 


### PR DESCRIPTION
## Description

Harden develop and production GitHub release updates against masked API failures, mutable branch refs, and overlapping release runs.

The failed develop run suppressed stderr from `gh release view`. Any nonzero result, including a transient API failure, was therefore treated as "release absent." Deletion was skipped and `gh release create` then failed because the tag still existed. The production draft guard and post-merge publisher used the same error-suppression pattern.

```mermaid
sequenceDiagram
    participant W as Release workflow
    participant API as GitHub API
    participant R as Existing release

    W->>API: gh release view tag
    API--xW: Transient API error
    Note over W: stderr discarded and nonzero treated as absent
    W-->>R: Skip expected existing-release path
    alt Rolling develop release
        W->>API: gh release create latest-develop
        API-->>W: Error: tag already exists
    else Production release
        W-->>W: Report a misleading missing-release error
    end
    Note over R: Existing release remains intact
```

This change:

- resolves the `develop` tip once and pins assets, prerelease metadata, and Docker builds to that immutable SHA
- serializes develop releases with one fixed concurrency group and queues runs instead of cancelling them
- serializes all production publication runs so an older run cannot update `latest` after a newer release
- treats a release as absent only for an explicit not-found response
- preserves authentication, rate-limit, and transient API errors as the reported failure
- applies the check to the pre-merge production draft guard and post-merge publisher
- isolates conflict-label concurrency by PR number so unrelated `pull_request_target` runs do not cancel each other
- documents the develop and production release invariants in both contributor references

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Validation

- `actionlint` passed for all changed workflows
- Pre-commit passed for all changed files
- `git diff --check`
- GitHub test matrix passed on Python 3.10 through 3.14 before the final workflow-only concurrency commit
- Verified `gh release view` returns `release not found` for a missing release

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have modified this PR to merge to the develop branch
