### PR TITLE
test(web-ui): add responsive overflow coverage

### DIFF
--- a/.github/workflows/web-ui-tests.yml
+++ b/.github/workflows/web-ui-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 24
+          node-version-file: package.json
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/web-ui-tests.yml
+++ b/.github/workflows/web-ui-tests.yml
@@ -1,0 +1,58 @@
+name: Web UI Tests
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - develop
+    paths:
+      - "web-ui/**"
+      - "tests/web-ui/**"
+      - "package.json"
+      - "package-lock.json"
+      - "playwright.config.js"
+      - ".github/workflows/web-ui-tests.yml"
+  pull_request:
+    branches:
+      - master
+      - main
+      - develop
+    paths:
+      - "web-ui/**"
+      - "tests/web-ui/**"
+      - "package.json"
+      - "package-lock.json"
+      - "playwright.config.js"
+      - ".github/workflows/web-ui-tests.yml"
+
+concurrency:
+  group: web-ui-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  responsive-overflow:
+    name: Responsive overflow
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install chromium
+
+      - name: Run responsive overflow tests
+        run: npm run test:web-ui

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ entities.json
 .coverage.*
 htmlcov/
 .pytest_cache/
+
+# Playwright runtime artifacts
+node_modules/
+playwright-report/
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+    "name": "qbit-manage-web-ui-tests",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "qbit-manage-web-ui-tests",
+            "devDependencies": {
+                "@playwright/test": "1.61.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+            "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.61.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+            "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.61.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+            "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "qbit-manage-web-ui-tests",
+    "private": true,
+    "type": "module",
+    "engines": {
+        "node": ">=20"
+    },
+    "scripts": {
+        "test:web-ui": "playwright test"
+    },
+    "devDependencies": {
+        "@playwright/test": "1.61.1"
+    }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/web-ui",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    browserName: "chromium",
+    headless: true,
+  },
+});

--- a/tests/web-ui/responsive-overflow.spec.js
+++ b/tests/web-ui/responsive-overflow.spec.js
@@ -1,0 +1,200 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(currentDirectory, "../..");
+const webUiRoot = path.join(repositoryRoot, "web-ui");
+const cssRoot = path.join(repositoryRoot, "web-ui/css");
+const viewportWidths = [320, 375, 390, 430, 768, 1024, 1280, 1920];
+const longTorrentPath = `/downloads/${"nested-directory/".repeat(20)}torrent-file-with-an-intentionally-long-name.mkv`;
+
+async function loadRealApplication(page) {
+  await page.route("http://qbm.test/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    const relativePath = pathname === "/" ? "index.html" : pathname.replace(/^\/static\//, "").replace(/^\//, "");
+    const filePath = path.resolve(webUiRoot, relativePath);
+
+    if (!filePath.startsWith(`${webUiRoot}${path.sep}`) || !fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+      await route.fulfill({ status: 404, body: "Not found" });
+      return;
+    }
+    await route.fulfill({ path: filePath });
+  });
+  await page.route("https://fonts.googleapis.com/**", (route) => route.abort());
+  await page.goto("http://qbm.test/", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(() => window.headerComponent !== undefined);
+}
+
+function componentStylesheets() {
+  const manifest = fs.readFileSync(path.join(cssRoot, "components.css"), "utf8");
+  return [...manifest.matchAll(/@import ['"](.+?)['"];?/g)].map((match) => path.resolve(cssRoot, match[1]));
+}
+
+async function loadApplicationStyles(page) {
+  const stylesheets = [
+    path.join(cssRoot, "themes.css"),
+    path.join(cssRoot, "main.css"),
+    ...componentStylesheets(),
+    path.join(cssRoot, "responsive.css"),
+  ];
+
+  for (const stylesheet of stylesheets) {
+    await page.addStyleTag({ path: stylesheet });
+  }
+
+  await page.addStyleTag({ content: "*, *::before, *::after { animation: none !important; transition: none !important; }" });
+}
+
+function representativeApplicationMarkup(width) {
+  const compactActionClass = width < 640 ? " btn-icon-only" : "";
+  const actionLabel = width < 640 ? "" : "Action";
+  return `<!doctype html>
+    <html lang="en">
+    <head><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+    <body>
+    <div id="app" class="app">
+      <header class="header">
+        <div class="header-left"><span class="app-title">qBit Manage</span></div>
+        <div class="header-right">
+          <div class="header-actions">
+            <button class="btn btn-icon">Undo</button>
+            <button class="btn btn-primary${compactActionClass}">${actionLabel}</button>
+            <button class="btn btn-secondary${compactActionClass}">${actionLabel}</button>
+            <button class="btn btn-secondary${compactActionClass}">${actionLabel}</button>
+          </div>
+        </div>
+      </header>
+      <div class="main-content">
+        <nav class="sidebar"><div class="sidebar-header"><h3>Configuration Sections</h3></div></nav>
+        <main class="content">
+          <div class="content-header"><h2>qBittorrent Connection</h2></div>
+          <section class="section-content">
+            <div class="card">
+              <div class="card-header">Configuration editor</div>
+              <div class="card-body">
+                <div class="form-group"><label class="form-label">Root directory</label>
+                  <input class="form-input" value="${longTorrentPath}">
+                </div>
+              </div>
+            </div>
+            <div class="log-viewer">
+              <div class="log-viewer-header"><span class="log-viewer-title">Run log</span></div>
+              <div class="log-viewer-content"><div class="log-entry">
+                <span class="log-timestamp">2026-07-16 12:00:00</span>
+                <span class="log-level">INFO</span><span class="log-message">${longTorrentPath}</span>
+              </div></div>
+            </div>
+          </section>
+        </main>
+      </div>
+      <footer class="footer"><span>qBit Manage</span></footer>
+    </div>
+    <aside class="command-panel-drawer active">
+      <div class="command-panel-header"><h3>Command output</h3></div>
+      <div class="command-panel-content">
+        <div class="log-viewer-content"><div class="log-entry"><span class="log-message">${longTorrentPath}</span></div></div>
+      </div>
+    </aside>
+    </body>
+    </html>`;
+}
+
+for (const width of viewportWidths) {
+  test(`contains representative content at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 900 });
+    await page.setContent(representativeApplicationMarkup(width));
+    await loadApplicationStyles(page);
+
+    const dimensions = await page.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+      overflowingElements: [...document.querySelectorAll("body *")]
+        .filter((element) => {
+          const bounds = element.getBoundingClientRect();
+          const closedSidebar = element.closest(".sidebar:not(.mobile-open)");
+          if (closedSidebar) {
+            const sidebarBounds = closedSidebar.getBoundingClientRect();
+            return bounds.left < sidebarBounds.left || bounds.right > sidebarBounds.right;
+          }
+          return bounds.left < 0 || bounds.right > document.documentElement.clientWidth;
+        })
+        .slice(0, 10)
+        .map((element) => ({
+          classes: element.className,
+          tag: element.tagName,
+          width: element.getBoundingClientRect().width,
+        })),
+    }));
+
+    expect(dimensions.scrollWidth, JSON.stringify(dimensions)).toBe(dimensions.clientWidth);
+    expect(dimensions.overflowingElements, JSON.stringify(dimensions)).toEqual([]);
+  });
+}
+
+for (const width of viewportWidths) {
+  test(`real application shell does not overflow at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 900 });
+    await loadRealApplication(page);
+    await page.evaluate((longPath) => {
+      const section = document.getElementById("section-content");
+      section.innerHTML = `<div class="card"><div class="card-body"><input class="form-input" value="${longPath}"></div></div>`;
+
+      const drawer = document.getElementById("command-panel-drawer");
+      drawer.classList.remove("hidden");
+      drawer.classList.add("active");
+      drawer.innerHTML = `<div class="command-panel-content"><div class="log-viewer-content"><div class="log-entry"><span class="log-message">${longPath}</span></div></div></div>`;
+    }, longTorrentPath);
+
+    const dimensions = await page.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+      overflowingElements: [...document.querySelectorAll("body *")]
+        .filter((element) => {
+          const bounds = element.getBoundingClientRect();
+          for (
+            let ancestor = element.parentElement;
+            ancestor && ancestor !== document.body && ancestor !== document.documentElement;
+            ancestor = ancestor.parentElement
+          ) {
+            if (["auto", "scroll", "hidden", "clip"].includes(getComputedStyle(ancestor).overflowX)) return false;
+          }
+          const closedSidebar = element.closest(".sidebar:not(.mobile-open)");
+          if (closedSidebar) {
+            const sidebarBounds = closedSidebar.getBoundingClientRect();
+            return bounds.left < sidebarBounds.left || bounds.right > sidebarBounds.right;
+          }
+          return bounds.left < 0 || bounds.right > document.documentElement.clientWidth;
+        })
+        .slice(0, 10)
+        .map((element) => ({
+          classes: element.className,
+          tag: element.tagName,
+          right: element.getBoundingClientRect().right,
+          width: element.getBoundingClientRect().width,
+        })),
+    }));
+    expect(dimensions.scrollWidth, JSON.stringify(dimensions)).toBe(dimensions.clientWidth);
+    expect(dimensions.overflowingElements, JSON.stringify(dimensions)).toEqual([]);
+  });
+}
+
+test("real header restores actions at the canonical 640px breakpoint", async ({ page }) => {
+  await page.setViewportSize({ width: 639, height: 900 });
+  await loadRealApplication(page);
+  const saveButton = page.locator("#save-config-btn");
+  await expect(saveButton).toHaveClass(/btn-icon-only/);
+  await expect(saveButton).toHaveCSS("width", "32px");
+  const compactLabels = await saveButton.evaluate((button) =>
+    [...button.childNodes].filter((node) => node.nodeType === Node.TEXT_NODE).map((node) => node.textContent.trim())
+  );
+  expect(compactLabels).not.toHaveLength(0);
+  expect(compactLabels.every((label) => label === "")).toBe(true);
+
+  await page.setViewportSize({ width: 640, height: 900 });
+  await expect(saveButton).not.toHaveClass(/btn-icon-only/);
+  await expect(saveButton).not.toHaveCSS("width", "32px");
+  await expect(saveButton).toContainText("Save");
+});

--- a/tests/web-ui/responsive-overflow.spec.js
+++ b/tests/web-ui/responsive-overflow.spec.js
@@ -10,6 +10,9 @@ const webUiRoot = path.join(repositoryRoot, "web-ui");
 const cssRoot = path.join(repositoryRoot, "web-ui/css");
 const viewportWidths = [320, 375, 390, 430, 768, 1024, 1280, 1920];
 const longTorrentPath = `/downloads/${"nested-directory/".repeat(20)}torrent-file-with-an-intentionally-long-name.mkv`;
+// Sub-pixel layout can put a bound a fraction of a pixel past its container
+// (e.g. 640.0001) with no visible overflow; ignore differences below this.
+const overflowEpsilonPx = 0.5;
 
 async function loadRealApplication(page) {
   await page.route("http://qbm.test/**", async (route) => {
@@ -108,7 +111,7 @@ for (const width of viewportWidths) {
     await page.setContent(representativeApplicationMarkup(width));
     await loadApplicationStyles(page);
 
-    const dimensions = await page.evaluate(() => ({
+    const dimensions = await page.evaluate((epsilon) => ({
       clientWidth: document.documentElement.clientWidth,
       scrollWidth: document.documentElement.scrollWidth,
       overflowingElements: [...document.querySelectorAll("body *")]
@@ -117,9 +120,9 @@ for (const width of viewportWidths) {
           const closedSidebar = element.closest(".sidebar:not(.mobile-open)");
           if (closedSidebar) {
             const sidebarBounds = closedSidebar.getBoundingClientRect();
-            return bounds.left < sidebarBounds.left || bounds.right > sidebarBounds.right;
+            return bounds.left < sidebarBounds.left - epsilon || bounds.right > sidebarBounds.right + epsilon;
           }
-          return bounds.left < 0 || bounds.right > document.documentElement.clientWidth;
+          return bounds.left < -epsilon || bounds.right > document.documentElement.clientWidth + epsilon;
         })
         .slice(0, 10)
         .map((element) => ({
@@ -127,7 +130,7 @@ for (const width of viewportWidths) {
           tag: element.tagName,
           width: element.getBoundingClientRect().width,
         })),
-    }));
+    }), overflowEpsilonPx);
 
     expect(dimensions.scrollWidth, JSON.stringify(dimensions)).toBe(dimensions.clientWidth);
     expect(dimensions.overflowingElements, JSON.stringify(dimensions)).toEqual([]);
@@ -148,7 +151,7 @@ for (const width of viewportWidths) {
       drawer.innerHTML = `<div class="command-panel-content"><div class="log-viewer-content"><div class="log-entry"><span class="log-message">${longPath}</span></div></div></div>`;
     }, longTorrentPath);
 
-    const dimensions = await page.evaluate(() => ({
+    const dimensions = await page.evaluate((epsilon) => ({
       clientWidth: document.documentElement.clientWidth,
       scrollWidth: document.documentElement.scrollWidth,
       overflowingElements: [...document.querySelectorAll("body *")]
@@ -164,9 +167,9 @@ for (const width of viewportWidths) {
           const closedSidebar = element.closest(".sidebar:not(.mobile-open)");
           if (closedSidebar) {
             const sidebarBounds = closedSidebar.getBoundingClientRect();
-            return bounds.left < sidebarBounds.left || bounds.right > sidebarBounds.right;
+            return bounds.left < sidebarBounds.left - epsilon || bounds.right > sidebarBounds.right + epsilon;
           }
-          return bounds.left < 0 || bounds.right > document.documentElement.clientWidth;
+          return bounds.left < -epsilon || bounds.right > document.documentElement.clientWidth + epsilon;
         })
         .slice(0, 10)
         .map((element) => ({
@@ -175,7 +178,7 @@ for (const width of viewportWidths) {
           right: element.getBoundingClientRect().right,
           width: element.getBoundingClientRect().width,
         })),
-    }));
+    }), overflowEpsilonPx);
     expect(dimensions.scrollWidth, JSON.stringify(dimensions)).toBe(dimensions.clientWidth);
     expect(dimensions.overflowingElements, JSON.stringify(dimensions)).toEqual([]);
   });

--- a/web-ui/css/main.css
+++ b/web-ui/css/main.css
@@ -119,6 +119,7 @@ body {
 .sidebar-toggle {
     width: 2.25rem;
     height: 2.25rem;
+    overflow: hidden;
     padding: 0;
     border: none;
     background: transparent;
@@ -232,6 +233,7 @@ body {
   position: relative;
   width: 2.25rem;
   height: 2.25rem;
+  overflow: hidden;
   padding: 0;
   border: none;
   background: transparent;
@@ -374,17 +376,14 @@ body {
 }
 
 
-@media (max-width: 640px) {
-  .header-actions .btn-icon-only {
-    width: 2rem;
-    height: 2rem;
-    padding: 0;
-  }
-
+.header-actions .btn-icon-only {
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
 }
 
 /* Ensure buttons restore properly when transitioning from icon-only to full size */
-@media (min-width: 641px) {
+@media (min-width: 640px) {
   .header-actions .btn:not(.btn-icon) {
     width: auto;
     height: auto;

--- a/web-ui/css/main.css
+++ b/web-ui/css/main.css
@@ -233,7 +233,6 @@ body {
   position: relative;
   width: 2.25rem;
   height: 2.25rem;
-  overflow: hidden;
   padding: 0;
   border: none;
   background: transparent;
@@ -251,6 +250,9 @@ body {
 
 .theme-toggle .material-icons {
   font-size: 1.125rem;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
   transition: all var(--transition-fast);
 }
 

--- a/web-ui/css/responsive.css
+++ b/web-ui/css/responsive.css
@@ -1,4 +1,10 @@
-/* Mobile First Responsive Design */
+/* Mobile First Responsive Design
+ *
+ * Target viewport breakpoints: 640px, 768px, 1024px, and 1280px.
+ * Migrate one layout family at a time and verify each change with the
+ * responsive overflow tests. Existing queries remain until their family is
+ * migrated so this scale does not silently change established layouts.
+ */
 
 /* Global touch improvements */
 @media (pointer: coarse) {


### PR DESCRIPTION
## Description

Adds the first bounded responsive-layout implementation slice for #1287.

- Tests representative overflow content at eight viewport widths.
- Loads the real `web-ui/index.html`, application styles, and header JavaScript at the same widths.
- Asserts representative elements remain within the viewport and the real document does not gain horizontal scrolling.
- Covers the 639 to 640 pixel header-action transition.
- Contains fallback Material Icon text inside the theme toggle when the external font is unavailable.
- Adds the path-filtered Web UI workflow on a GitHub-hosted runner.

Fixes part of #1287.

## Validation

- `npm run test:web-ui` (17 passed)
- `node --check tests/web-ui/responsive-overflow.spec.js`
- Pre-commit passed for changed files
- `git diff --check`

## Type of change

- [x] Bug fix
- [x] Test coverage
- [x] Documentation update
