### PR TITLE
fix(config): guard missing parent and stop overwriting existing subparent values

### DIFF
--- a/modules/util.py
+++ b/modules/util.py
@@ -731,9 +731,9 @@ class check:
                         yaml.data[parent] = {}
                     if subparent not in yaml.data[parent] or not yaml.data[parent][subparent]:
                         yaml.data[parent][subparent] = {attribute: default}
-                    elif attribute not in yaml.data[parent]:
-                        if isinstance(yaml.data[parent][subparent], str):
-                            yaml.data[parent][subparent] = {attribute: default}
+                    elif isinstance(yaml.data[parent][subparent], str):
+                        yaml.data[parent][subparent] = {attribute: default}
+                    elif attribute not in yaml.data[parent][subparent]:
                         yaml.data[parent][subparent][attribute] = default
                     else:
                         endline = ""

--- a/modules/util.py
+++ b/modules/util.py
@@ -727,6 +727,8 @@ class check:
                 yaml = YAML(self.config.config_path)
                 if subparent:
                     endline = f"\n{subparent} sub-attribute {attribute} added to config"
+                    if parent not in yaml.data or not isinstance(yaml.data[parent], dict):
+                        yaml.data[parent] = {}
                     if subparent not in yaml.data[parent] or not yaml.data[parent][subparent]:
                         yaml.data[parent][subparent] = {attribute: default}
                     elif attribute not in yaml.data[parent]:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -493,3 +493,43 @@ class TestCheckForAttributeSubparentSave:
         saved = config_file.read_text(encoding="utf-8")
         assert "example.com:" in saved
         assert "other.com:" in saved
+
+
+class TestCheckForAttributeSubparentPreservesExisting:
+    def test_new_attribute_on_existing_subparent_is_added_not_replaced(self, tmp_path):
+        """A second attribute on an already-configured subparent must be added
+        alongside the existing one, not replace it."""
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("tracker:\n  passthepopcorn:\n    tag: PassThePopcorn\n", encoding="utf-8")
+
+        checker = check(_FakeConfig(str(config_file)))
+        checker.check_for_attribute(
+            {}, "cat", parent="tracker", subparent="passthepopcorn", default="AutoCat", var_type="str", do_print=False
+        )
+
+        saved = config_file.read_text(encoding="utf-8")
+        assert "tag: PassThePopcorn" in saved
+        assert "cat: AutoCat" in saved
+
+    def test_already_set_attribute_is_not_overwritten(self, tmp_path):
+        """Regression test: a subparent attribute that's already configured
+        (e.g. a user-customized tracker tag) must survive a later
+        check_for_attribute call for that same attribute, not get silently
+        reset back to the computed default."""
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("tracker:\n  passthepopcorn:\n    tag: PassThePopcorn\n", encoding="utf-8")
+
+        checker = check(_FakeConfig(str(config_file)))
+        checker.check_for_attribute(
+            {},
+            "tag",
+            parent="tracker",
+            subparent="passthepopcorn",
+            default="OVERWRITTEN-DEFAULT",
+            var_type="str",
+            do_print=False,
+        )
+
+        saved = config_file.read_text(encoding="utf-8")
+        assert "tag: PassThePopcorn" in saved
+        assert "OVERWRITTEN-DEFAULT" not in saved

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -12,6 +12,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from modules.util import check
 from modules.util import format_stats_summary
 from modules.util import get_list
 from modules.util import guess_branch
@@ -437,3 +438,58 @@ class TestPathReplace:
         result = path_replace(["/data/file.txt"], ["/data/"], ["/mnt/"])
         assert "mnt" in result
         assert "file.txt" in result
+
+
+# ── check.check_for_attribute ───────────────────────────────────────────────
+
+
+class _FakeConfig:
+    def __init__(self, config_path):
+        self.config_path = config_path
+
+
+class TestCheckForAttributeSubparentSave:
+    def test_missing_top_level_parent_does_not_raise(self, tmp_path):
+        """Regression test for qbit_manage#1327: a subparent write under a
+        parent key absent from the on-disk YAML (e.g. no top-level `tracker:`
+        section) must not raise KeyError when persisting the generated value."""
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("qbt:\n  host: localhost:8080\n", encoding="utf-8")
+
+        checker = check(_FakeConfig(str(config_file)))
+        result = checker.check_for_attribute(
+            {},
+            "tag",
+            parent="tracker",
+            subparent="example.com",
+            default="example",
+            var_type="list",
+            do_print=False,
+        )
+
+        assert result == "example"
+        saved = config_file.read_text(encoding="utf-8")
+        assert "tracker:" in saved
+        assert "example.com:" in saved
+
+    def test_existing_parent_without_subparent_key(self, tmp_path):
+        """Same regression, but `tracker:` already exists with a sibling
+        subparent key — the new subparent must be added alongside it."""
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("qbt:\n  host: localhost:8080\ntracker:\n  other.com:\n    tag: [other]\n", encoding="utf-8")
+
+        checker = check(_FakeConfig(str(config_file)))
+        result = checker.check_for_attribute(
+            {},
+            "tag",
+            parent="tracker",
+            subparent="example.com",
+            default="example",
+            var_type="list",
+            do_print=False,
+        )
+
+        assert result == "example"
+        saved = config_file.read_text(encoding="utf-8")
+        assert "example.com:" in saved
+        assert "other.com:" in saved


### PR DESCRIPTION
## Description

Fixes #1327. The reported `KeyError: 'tracker'` in `process_torrent_issues` and `Tag NoHardLinks` is not caused by a qBittorrent v5.2.3 API change — it's a config-write bug in `check_for_attribute()` (`modules/util.py`) that fires whenever a torrent's tracker host isn't yet present in the user's `tracker:` config section.

**Scope note:** this PR now fixes two related bugs in the same few lines of `check_for_attribute()`'s subparent-save branch — the reported KeyError, plus a silent-data-loss bug Copilot's own suppressed review comment surfaced while reviewing the first fix.

## Bug 1 — `KeyError: 'tracker'` (the reported issue)

`get_tags()` calls `check_for_attribute(..., parent="tracker", subparent=<tracker host>, save=True)` for every tracker not already listed under a `tracker:` key. Inside `check_for_attribute`'s subparent branch:

```python
if subparent not in yaml.data[parent] or not yaml.data[parent][subparent]:
```

this indexes `yaml.data[parent]` (i.e. `yaml.data["tracker"]`) directly, with no check that `"tracker"` exists in the on-disk YAML at all. The sibling no-subparent branch a few lines below already guards this correctly (`if parent not in yaml.data or not yaml.data[parent]:`) — the subparent branch was just missing the equivalent check.

Any config with no top-level `tracker:` section (like the reporter's, see the issue's attached config) hits this on the very first previously-unseen tracker host.

**Fix:** add the same existence/type guard the no-subparent branch already has, before indexing:

```python
if parent not in yaml.data or not isinstance(yaml.data[parent], dict):
    yaml.data[parent] = {}
```

## Bug 2 — existing subparent attributes silently overwritten

Found via Copilot's own suppressed low-confidence comment on this PR (`modules/util.py:735`) while reviewing bug 1's fix — it flagged the check but wasn't sure it was a real bug. It is, confirmed by reproduction:

```python
elif attribute not in yaml.data[parent]:
```

checks whether `attribute` (e.g. `"tag"`) is a key in `yaml.data[parent]` — the tracker-level dict, keyed by tracker **hostnames** — instead of `yaml.data[parent][subparent]`, the specific tracker's own dict, keyed by **attribute names**. Since an attribute name is essentially never also a tracker hostname, this condition was almost always true.

**Practical effect:** any already-configured subparent attribute (e.g. a user's manually-set tracker tag) gets silently reset back to the caller's computed default on the next `check_for_attribute` call for that tracker — which happens on every run once any other attribute is checked for the same tracker.

Reproduction (before fix):

```python
# Starting config: tracker: {passthepopcorn: {tag: PassThePopcorn}}
checker.check_for_attribute({}, "cat", parent="tracker", subparent="passthepopcorn", default="AutoCat", ...)
# → tracker: {passthepopcorn: {tag: PassThePopcorn, cat: AutoCat}}   -- correct

checker.check_for_attribute({}, "tag", parent="tracker", subparent="passthepopcorn", default="OVERWRITTEN-DEFAULT", ...)
# → tracker: {passthepopcorn: {tag: OVERWRITTEN-DEFAULT, cat: AutoCat}}   -- BUG: user's tag silently lost
```

**Fix:** check the subparent's own dict, not the parent's:

```python
elif attribute not in yaml.data[parent][subparent]:
```

## Validation

- Regression test reproducing the exact `KeyError: 'tracker'` against the fix-reverted code (confirmed failing), passes with the fix.
- Regression test reproducing the exact overwrite against the fix-reverted code (confirmed failing), passes with the fix.
- Companion tests for the existing-parent and new-attribute-on-existing-subparent paths, to make sure neither fix regresses normal operation.
- Full suite: `.venv/bin/pytest -q --no-cov` — 348 passed.
- Ruff check + format clean.

## Type of change

- [x] Bug fix
