### PR TITLE
ci: retry github-script steps on transient GitHub API errors

### DIFF
--- a/.github/workflows/auto-close-qbit-version-issues.yml
+++ b/.github/workflows/auto-close-qbit-version-issues.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Detect and close
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
+          retries: "3"
           script: |
             const title = context.payload.issue.title || '';
 

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -419,6 +419,7 @@ jobs:
       - name: Clean up temporary build artifacts
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
+          retries: "3"
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,

--- a/.github/workflows/issue-lifecycle.yml
+++ b/.github/workflows/issue-lifecycle.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Add status:added-to-develop to issues this PR fixes
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
+          retries: "3"
           script: |
             // Strip HTML comments so PR-template boilerplate ("Fixes # (issue)") can't match.
             const body = (context.payload.pull_request.body || '').replace(/<!--[\s\S]*?-->/g, '');
@@ -77,6 +78,7 @@ jobs:
       - name: Close all open issues labeled status:added-to-develop
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
+          retries: "3"
           script: |
             const pr = context.payload.pull_request;
             const version = pr.head.ref.replace('release/', '');

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Add build label if Cargo.toml/Cargo.lock changed
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
+          retries: "3"
           script: |
             const files = await github.paginate(github.rest.pulls.listFiles, {
               ...context.repo, pull_number: context.payload.pull_request.number, per_page: 100,


### PR DESCRIPTION
## Description

`PR #1328`'s "Auto-apply build label for Cargo changes" check failed on a transient GitHub API 503 ("No server is currently available to service your request"), not a real code issue. Root cause: `actions/github-script` defaults its `retries` input to `"0"`, so any transient 5xx crashes the whole job instead of being retried — 503 is not in the action's default `retry-exempt-status-codes` list (`400,401,403,404,422`), so it's retryable, it just wasn't being retried.

## Fix

Set `retries: "3"` on every `actions/github-script` step in the repo (5 steps across 4 workflow files) so a single transient GitHub API blip doesn't fail CI:

- `labeler.yml` — Cargo build-label step (the one that actually failed)
- `auto-close-qbit-version-issues.yml`
- `build-binaries.yml` — artifact cleanup step
- `issue-lifecycle.yml` — both steps

## Validation

- `pre-commit run` on the 4 changed files: passed (yaml check, trailing whitespace, etc.)
- No script logic changed — this only adds a retry input.

## Type of change

- [x] Bug fix (CI reliability)
