### PR TITLE
fix(ci): stop release-pr.yml from double-incrementing the guessed patch version

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -83,6 +83,14 @@ jobs:
 
           IFS='.' read -r MAJOR MINOR PATCH <<< "$base"
 
+          # develop's VERSION already carries a pre-guessed next-patch base
+          # (update-develop-branch.yml bumps PATCH+1 after every master push,
+          # so develop's version always has higher SemVer precedence than the
+          # last release). A "patch" release publishes that guessed base
+          # as-is; incrementing it again here would skip a version number
+          # (e.g. develop at 4.11.1-developN publishing 4.11.2, with
+          # v4.11.1 never released). "minor"/"major" intentionally discard
+          # the guessed patch and reset lower segments.
           case "${{ inputs.version_bump_type }}" in
             major)
               NEW_VERSION="$((MAJOR + 1)).0.0"
@@ -91,7 +99,7 @@ jobs:
               NEW_VERSION="${MAJOR}.$((MINOR + 1)).0"
               ;;
             patch|*)
-              NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+              NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
               ;;
           esac
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -186,11 +186,21 @@ Version strings live in a single file: `VERSION` at the repo root.
   removed from `.pre-commit-config.yaml`; bumping is now CI-driven.
 - After a master merge, `update-develop-branch.yml` sets the next version:
   it strips the release suffix, bumps the patch segment by 1, and appends
-  `-develop1`. Example: `4.7.2` → `4.7.3-develop1`.
+  `-develop1`. Example: `4.7.2` → `4.7.3-develop1`. This keeps develop's
+  version at a higher SemVer precedence than the release it follows, since
+  it's an in-progress prerelease of *at least* the next patch.
 
-**Major/minor bumps** are handled by the Release PR workflow's `version_bump_type`
-input — the workflow computes the new base version, writes it to the `release/v<NEW>`
-branch, and opens the PR from that branch. `develop` is not modified during this step.
+**Bump types** are handled by the Release PR workflow's `version_bump_type`
+input, which computes the new base version and writes it to the `release/v<NEW>`
+branch (`develop` is not modified during this step):
+
+- `patch` publishes develop's pre-guessed base **as-is** (no further
+  increment) — e.g. develop at `4.7.3-develop5` → release `4.7.3`. Adding
+  another `+1` here would skip a version number, since develop's base is
+  already the next-patch candidate.
+- `minor`/`major` intentionally discard the guessed patch and reset lower
+  segments — e.g. develop at `4.7.3-develop5` → `minor` release `4.8.0`,
+  `major` release `5.0.0`.
 
 ---
 


### PR DESCRIPTION
## Problem

A patch release run after any other release skips a version number. Concretely: `update-develop-branch.yml` pre-guesses the next-patch candidate after every master push (e.g. release `v4.11.0` → develop reseeds to `4.11.1-develop1`, keeping develop's version at a higher SemVer precedence than the release it follows — this part is correct and intentional, see "Why develop's version looks 'ahead'" below). But `release-pr.yml`'s `patch` bump case adds **another** `+1` on top of that already-guessed base. So if the next release after `v4.11.0` were a `patch`, it would compute `4.11.2` and publish that — `v4.11.1` is silently skipped and never released.

Live repro on this repo right now: `origin/develop` VERSION is `4.11.1-develop1` (correct guess, following the real `v4.11.0` minor release from PR #1335). If a `patch` release were run today, unpatched `release-pr.yml` would publish `v4.11.2`, not `v4.11.1`.

## Why develop's version looks "ahead" (not a bug)

`develop` showing `4.11.1-developN` right after `v4.11.0` released is expected: SemVer precedence rules mean a prerelease tag (`-develop1`) only lowers precedence *within the same X.Y.Z*, so `4.11.0-develop1` would actually sort **behind** the already-published `v4.11.0` — wrong direction for an in-progress branch. Guessing the next patch ahead of time (`4.11.1-develop1`) keeps develop's version correctly ahead of the last release at all times, which is the standard convention for rolling/nightly builds. Confirmed this repo's own version-check code (`modules/util.py`, `modules/web_api.py`) doesn't rely on strict SemVer-library precedence either way, so this part was never functionally broken — it's about not skipping a real release number, not about the develop display.

## Fix

`release-pr.yml`'s `patch` case now publishes develop's pre-guessed base **as-is**, with no further increment — since that guess already *is* the next-patch candidate. `minor`/`major` are unaffected: they already correctly discard the guessed patch and reset lower segments (`4.7.3-develop5` → minor `4.8.0`, major `5.0.0`).

`update-develop-branch.yml` is unchanged from `develop` — an earlier version of this PR modified it instead, but that broke the SemVer-precedence property described above for no corresponding benefit once the real bug (the double-increment in `release-pr.yml`) is fixed at the source. Reverted.

## Review notes for maintainer visibility

Adversarially reviewed by two independent models (Haiku + Codex) before finalizing. Haiku confirmed the first draft of this fix (the one that changed `update-develop-branch.yml`) with no issues found. Codex disagreed and correctly flagged that draft as a SemVer-precedence regression, and separately identified `release-pr.yml`'s patch case as the actual double-increment culprit — that reframing is what this final version implements. Verified independently that this repo's version-check code doesn't do strict precedence comparison either way, so neither the old nor new develop-display behavior was ever a functional risk — the real, fixed issue is the skipped release number.

Requesting @bobokun's review since this touches the release pipeline.