### PR TITLE
fix(web-ui): serve favicon and manifest under the mounted /static path

### DIFF
--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -8,11 +8,11 @@
     <link rel="stylesheet" href="static/css/components.css">
     <link rel="stylesheet" href="static/css/themes.css">
     <link rel="stylesheet" href="static/css/responsive.css">
-    <link rel="apple-touch-icon" sizes="180x180" href="img/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="img/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="img/favicon-16x16.png">
-    <link rel="manifest" href="img/site.webmanifest">
-    <link rel="shortcut icon" href="img/favicon.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="static/img/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="static/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="static/img/favicon-16x16.png">
+    <link rel="manifest" href="static/img/site.webmanifest">
+    <link rel="shortcut icon" href="static/img/favicon.ico">
     <!-- Material Icons -->
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>


### PR DESCRIPTION
## Description

The favicon/apple-touch-icon/manifest `<link>` tags in `web-ui/index.html` pointed at `img/...`, but the icon assets themselves already exist under `web-ui/img/` and were never actually broken as files — the FastAPI backend only mounts `web-ui/` at `/static` (`modules/web_api.py`), matching the `static/css/...` links already used for stylesheets on the same page. `img/...` isn't a registered route, so those requests fell through to the SPA catch-all route and got `index.html` back instead of the icon — no favicon ever rendered in the browser tab.

Fix: point the icon/manifest hrefs at `static/img/...`, consistent with the existing CSS link convention on the same page.

Verified with a minimal ASGI server using the same `StaticFiles` mount as production: all 5 paths (`favicon.ico`, `favicon-32x32.png`, `favicon-16x16.png`, `apple-touch-icon.png`, `site.webmanifest`) return 200 with correct content-types under `static/img/...`; the old `img/...` path 404s.

Fixes #1348

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have modified this PR to merge to the develop branch
