### PR TITLE
feat(scripts): add API key option to mover

### DIFF
--- a/scripts/mover.py
+++ b/scripts/mover.py
@@ -22,6 +22,7 @@ parser = argparse.ArgumentParser(prog="Qbit Mover", description="Stop torrents a
 parser.add_argument("--host", help="qbittorrent host including port", required=True)
 parser.add_argument("-u", "--user", help="qbittorrent user", default="admin")
 parser.add_argument("-p", "--password", help="qbittorrent password", default="adminadmin")
+parser.add_argument("-t", "--api-key", help="qBittorrent WebUI API key", default=None)
 parser.add_argument(
     "--ca-bundle",
     help="Path to a CA bundle used to verify the qBittorrent WebUI HTTPS certificate",
@@ -217,6 +218,7 @@ if __name__ == "__main__":
                 "host": args.host,
                 "username": args.user,
                 "password": args.password,
+                "api_key": args.api_key,
             }
 
             if args.ca_bundle:


### PR DESCRIPTION
## Description

Adds `--api-key` (alias `-t`) option to `scripts/mover.py` to support WebUI API work done in #1354

Related: #1341

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have modified this PR to merge to the develop branch
