### PR TITLE
fix: detect unregistered tracker when not last in the list (#1358)

### DIFF
--- a/modules/core/remove_unregistered.py
+++ b/modules/core/remove_unregistered.py
@@ -160,11 +160,8 @@ class RemoveUnregistered:
                 if any(TrackerStatus(trk.status) == TrackerStatus.WORKING for trk in real_trackers):
                     return
 
-                # A tracker still updating or not yet contacted is inconclusive --
-                # it may still come back working -- so never conclude "dead" on
-                # incomplete information; defer until every tracker has reported.
-                # These states are self-resolving, so this cannot strand a torrent
-                # the way a permanent-failure message could.
+                # UPDATING/NOT_CONTACTED is inconclusive and self-resolving;
+                # never conclude "dead" until every tracker has reported.
                 if any(
                     TrackerStatus(trk.status) in (TrackerStatus.UPDATING, TrackerStatus.NOT_CONTACTED) for trk in real_trackers
                 ):
@@ -181,9 +178,8 @@ class RemoveUnregistered:
                     # entries remain); nothing actionable.
                     return
 
-                # Scan ALL failing trackers for an unregistered message instead of
-                # only the last one -- a torrent whose unregistered tracker is not
-                # last in the list was previously never detected (issue #1358).
+                # Scan every failing tracker, not just the last one, so an
+                # unregistered tracker earlier in the list isn't missed.
                 unreg_tracker = None
                 for trk in failing_trackers:
                     trk_msg_up = (trk.msg or "").upper()
@@ -192,9 +188,9 @@ class RemoveUnregistered:
                     ):
                         unreg_tracker = trk
                         break
-                    if self.check_for_unregistered_torrents_in_bhd(
-                        self.qbt.get_tags(self.qbt.get_tracker_urls([trk])), trk_msg_up, torrent.hash
-                    ):
+                    # Pass the raw URL only; get_tags() runs config lookups we don't
+                    # need per-tracker here, so defer it until a match is found.
+                    if self.check_for_unregistered_torrents_in_bhd({"url": trk.url}, trk_msg_up, torrent.hash):
                         unreg_tracker = trk
                         break
 

--- a/modules/core/remove_unregistered.py
+++ b/modules/core/remove_unregistered.py
@@ -149,65 +149,84 @@ class RemoveUnregistered:
                     return
                 if not torrent.trackers:
                     return
-                tracker_working = False
-                for trk in torrent.trackers:
-                    if (
-                        trk.url.split(":")[0] in ["http", "https", "udp", "ws", "wss"]
-                        and TrackerStatus(trk.status) == TrackerStatus.WORKING
-                    ):
-                        tracker_working = True
-                if tracker_working:
+
+                real_trackers = [
+                    trk for trk in torrent.trackers if trk.url.split(":")[0] in ["http", "https", "udp", "ws", "wss"]
+                ]
+                if not real_trackers:
                     return
-                tracker = self.qbt.get_tags(self.qbt.get_tracker_urls([trk]))
-                msg_up = trk.msg.upper()
-                msg = trk.msg
-                if TrackerStatus(trk.status) in (
+
+                # A working tracker means the torrent is alive; nothing to remove.
+                if any(TrackerStatus(trk.status) == TrackerStatus.WORKING for trk in real_trackers):
+                    return
+
+                # A tracker still updating or not yet contacted is inconclusive --
+                # it may still come back working -- so never conclude "dead" on
+                # incomplete information; defer until every tracker has reported.
+                # These states are self-resolving, so this cannot strand a torrent
+                # the way a permanent-failure message could.
+                if any(
+                    TrackerStatus(trk.status) in (TrackerStatus.UPDATING, TrackerStatus.NOT_CONTACTED) for trk in real_trackers
+                ):
+                    return
+
+                terminal_failures = (
                     TrackerStatus.NOT_WORKING,
                     TrackerStatus.TRACKER_ERROR,
                     TrackerStatus.UNREACHABLE,
-                ):
-                    # Check for unregistered torrents
-                    if self.cfg_rem_unregistered:
-                        if list_in_text(msg_up, TorrentMessages.UNREGISTERED_MSGS) and not list_in_text(
-                            msg_up, TorrentMessages.IGNORE_MSGS
-                        ):
-                            if list_in_text(msg_up, self.rem_unregistered_ignore_list):
-                                logger.print_line(
-                                    f"Ignoring unregistered torrent {self.t_name} due to matching phrase found in ignore list.",
-                                    self.config.loglevel,
-                                )
-                            else:
-                                skip, age = self.is_within_grace(torrent)
-                                if skip:
-                                    logger.print_line(
-                                        logger.insert_space(
-                                            f"Skipping removal (within grace "
-                                            f"{self.rem_unregistered_grace_minutes} min, age {age:.1f} min): "
-                                            f"{self.t_name}",
-                                            3,
-                                        ),
-                                        self.config.loglevel,
-                                    )
-                                else:
-                                    self.check_max_limit_and_delete(msg, tracker, torrent)
+                )
+                failing_trackers = [trk for trk in real_trackers if TrackerStatus(trk.status) in terminal_failures]
+                if not failing_trackers:
+                    # No tracker reported a terminal failure (only DISABLED/pseudo
+                    # entries remain); nothing actionable.
+                    return
+
+                # Scan ALL failing trackers for an unregistered message instead of
+                # only the last one -- a torrent whose unregistered tracker is not
+                # last in the list was previously never detected (issue #1358).
+                unreg_tracker = None
+                for trk in failing_trackers:
+                    trk_msg_up = (trk.msg or "").upper()
+                    if list_in_text(trk_msg_up, TorrentMessages.UNREGISTERED_MSGS) and not list_in_text(
+                        trk_msg_up, TorrentMessages.IGNORE_MSGS
+                    ):
+                        unreg_tracker = trk
+                        break
+                    if self.check_for_unregistered_torrents_in_bhd(
+                        self.qbt.get_tags(self.qbt.get_tracker_urls([trk])), trk_msg_up, torrent.hash
+                    ):
+                        unreg_tracker = trk
+                        break
+
+                if self.cfg_rem_unregistered and unreg_tracker is not None:
+                    msg = unreg_tracker.msg
+                    msg_up = (msg or "").upper()
+                    tracker = self.qbt.get_tags(self.qbt.get_tracker_urls([unreg_tracker]))
+                    if list_in_text(msg_up, self.rem_unregistered_ignore_list):
+                        logger.print_line(
+                            f"Ignoring unregistered torrent {self.t_name} due to matching phrase found in ignore list.",
+                            self.config.loglevel,
+                        )
+                    else:
+                        skip, age = self.is_within_grace(torrent)
+                        if skip:
+                            logger.print_line(
+                                logger.insert_space(
+                                    f"Skipping removal (within grace "
+                                    f"{self.rem_unregistered_grace_minutes} min, age {age:.1f} min): "
+                                    f"{self.t_name}",
+                                    3,
+                                ),
+                                self.config.loglevel,
+                            )
                         else:
-                            if self.check_for_unregistered_torrents_in_bhd(tracker, msg_up, torrent.hash):
-                                skip, age = self.is_within_grace(torrent)
-                                if skip:
-                                    logger.print_line(
-                                        logger.insert_space(
-                                            f"Skipping removal (within grace "
-                                            f"{self.rem_unregistered_grace_minutes} min, age {age:.1f} min): "
-                                            f"{self.t_name}",
-                                            3,
-                                        ),
-                                        self.config.loglevel,
-                                    )
-                                else:
-                                    self.check_max_limit_and_delete(msg, tracker, torrent)
-                    # Tag any error torrents
-                    if self.cfg_tag_error and self.tag_error not in check_tags:
-                        self.tag_tracker_error(msg, tracker, torrent)
+                            self.check_max_limit_and_delete(msg, tracker, torrent)
+
+                # Tag any error torrents.
+                if self.cfg_tag_error and self.tag_error not in check_tags:
+                    error_tracker = unreg_tracker if unreg_tracker is not None else failing_trackers[0]
+                    tracker = self.qbt.get_tags(self.qbt.get_tracker_urls([error_tracker]))
+                    self.tag_tracker_error(error_tracker.msg, tracker, torrent)
 
             try:
                 process_single_torrent()

--- a/modules/qbittorrent.py
+++ b/modules/qbittorrent.py
@@ -198,7 +198,7 @@ class Qbt:
             for trk in torrent_trackers:
                 if trk.url.split(":")[0] in ["http", "https", "udp", "ws", "wss"]:
                     status = trk.status
-                    msg = trk.msg.upper()
+                    msg = (trk.msg or "").upper()
                     if TrackerStatus(trk.status) == TrackerStatus.WORKING:
                         working_tracker = True
                         break

--- a/tests/core/test_remove_unregistered.py
+++ b/tests/core/test_remove_unregistered.py
@@ -476,7 +476,7 @@ def _make_issue_qbt(torrent, *, config):
     return _make_qbt(torrents=[torrent], config=config, torrentinfo=torrentinfo)
 
 
-# ── process_torrent_issues (multi-tracker detection, issue #1358) ─────────────
+# ── process_torrent_issues (multi-tracker detection) ─────────────────────────
 
 
 def test_process_issues_detects_unregistered_when_not_last_tracker():
@@ -666,6 +666,38 @@ def test_process_issues_skips_when_any_tracker_working():
 
     assert not mock_del.called
     assert not qbt.config.notify_calls
+
+
+def test_process_issues_bhd_scan_defers_get_tags_until_match():
+    """get_tags() is only called once, for the matched tracker.
+
+    A non-BHD, non-unregistered failing tracker scanned before the BHD match
+    must not trigger a get_tags() lookup of its own.
+    """
+    cfg = FakeConfig(settings={**FakeConfig().settings, "rem_unregistered_grace_minutes": 0})
+    cfg.commands["tag_tracker_error"] = False
+    t = FakeTorrent(
+        name="T.BhdScan",
+        hash="hbhdscan",
+        category="Test",
+        added_on=int(time.time()) - 3600,
+        trackers=[
+            _Tracker(url="http://a.example/announce", status=4, msg="Connection timed out"),
+            _Tracker(url=_BHD_TRACKER_URL, status=4, msg="Dead"),
+        ],
+    )
+    qbt = _make_issue_qbt(t, config=cfg)
+    qbt._torrentissue_override = [t]
+    ru = make_remove_unregistered(qbt)
+
+    with (
+        patch.object(ru, "check_max_limit_and_delete") as mock_del,
+        patch.object(qbt, "get_tags", wraps=qbt.get_tags) as mock_get_tags,
+    ):
+        ru.process_torrent_issues()
+
+    assert mock_del.called
+    assert mock_get_tags.call_count == 1
 
 
 def test_grace_period_blocks_deletion():

--- a/tests/core/test_remove_unregistered.py
+++ b/tests/core/test_remove_unregistered.py
@@ -460,6 +460,187 @@ def test_full_flow_remove_unregistered_no_cross_seed():
         assert mock_del.called
 
 
+def _make_issue_qbt(torrent, *, config):
+    """Build a FakeQbtManager where *torrent* is the sole torrentissue entry.
+
+    process_torrent_issues() reads Category/msg/status out of torrentinfo keyed by
+    name, so mirror the torrent's own trackers into that structure.
+    """
+    torrentinfo = {
+        torrent.name: {
+            "Category": torrent.category,
+            "msg": [t.msg.upper() for t in torrent.trackers],
+            "status": [t.status for t in torrent.trackers],
+        }
+    }
+    return _make_qbt(torrents=[torrent], config=config, torrentinfo=torrentinfo)
+
+
+# ── process_torrent_issues (multi-tracker detection, issue #1358) ─────────────
+
+
+def test_process_issues_detects_unregistered_when_not_last_tracker():
+    """Unregistered tracker anywhere in the list is detected, not just the last one.
+
+    Regression for #1358: a torrent whose unregistered tracker is followed by
+    another failing tracker was previously missed because only the last tracker
+    was evaluated.
+    """
+    cfg = FakeConfig(settings={**FakeConfig().settings, "rem_unregistered_grace_minutes": 0})
+    t = FakeTorrent(
+        name="Sugar.2024.S01",
+        hash="hashsugar",
+        category="Test",
+        added_on=int(time.time()) - 3600,
+        trackers=[
+            _Tracker(url="http://a.example/announce", status=4, msg="some other tracker error"),
+            _Tracker(url="http://b.example/announce", status=4, msg="err: unregistered torrent"),
+        ],
+    )
+    cfg.commands["tag_tracker_error"] = False
+    qbt = _make_issue_qbt(t, config=cfg)
+    qbt._torrentissue_override = [t]
+    ru = make_remove_unregistered(qbt)
+
+    with patch.object(ru, "check_max_limit_and_delete") as mock_del:
+        ru.process_torrent_issues()
+
+    assert mock_del.called
+    assert "UNREGISTERED" in mock_del.call_args[0][0].upper()
+    assert not qbt.config.notify_calls  # no swallowed exception
+
+
+def test_process_issues_single_unregistered_still_deletes():
+    """The basic single-tracker unregistered case still triggers deletion."""
+    cfg = FakeConfig(settings={**FakeConfig().settings, "rem_unregistered_grace_minutes": 0})
+    cfg.commands["tag_tracker_error"] = False
+    t = FakeTorrent(
+        name="T.Single",
+        hash="hsingle",
+        category="Test",
+        added_on=int(time.time()) - 3600,
+        trackers=[_Tracker(url="http://a.example/announce", status=4, msg="Unregistered torrent")],
+    )
+    qbt = _make_issue_qbt(t, config=cfg)
+    qbt._torrentissue_override = [t]
+    ru = make_remove_unregistered(qbt)
+
+    with patch.object(ru, "check_max_limit_and_delete") as mock_del:
+        ru.process_torrent_issues()
+
+    assert mock_del.called
+    assert not qbt.config.notify_calls
+
+
+def test_process_issues_deletes_despite_host_not_found_sibling():
+    """Reporter's exact case: 'Host not found' + 'unregistered' still deletes.
+
+    A permanent authoritative DNS failure is not a temporary outage, so it must
+    not defer the removal.
+    """
+    cfg = FakeConfig(settings={**FakeConfig().settings, "rem_unregistered_grace_minutes": 0})
+    cfg.commands["tag_tracker_error"] = False
+    t = FakeTorrent(
+        name="T.HostNotFound",
+        hash="hhnf",
+        category="Test",
+        added_on=int(time.time()) - 3600,
+        trackers=[
+            _Tracker(url="http://a.example/announce", status=4, msg="Host not found (authoritative)"),
+            _Tracker(url="http://b.example/announce", status=4, msg="err: unregistered torrent"),
+        ],
+    )
+    qbt = _make_issue_qbt(t, config=cfg)
+    qbt._torrentissue_override = [t]
+    ru = make_remove_unregistered(qbt)
+
+    with patch.object(ru, "check_max_limit_and_delete") as mock_del:
+        ru.process_torrent_issues()
+
+    assert mock_del.called
+    assert not qbt.config.notify_calls
+
+
+def test_process_issues_deletes_when_sibling_tracker_times_out():
+    """A failed sibling tracker (e.g. timed out) does not block detection.
+
+    A single-snapshot message cannot distinguish a temporary outage from a
+    permanently-dead host, so message-based reachability is NOT used to defer.
+    Grace, max_torrents and the recyclebin remain the safety net.
+    """
+    cfg = FakeConfig(settings={**FakeConfig().settings, "rem_unregistered_grace_minutes": 0})
+    cfg.commands["tag_tracker_error"] = False
+    t = FakeTorrent(
+        name="T.Timeout",
+        hash="htimeout",
+        category="Test",
+        added_on=int(time.time()) - 3600,
+        trackers=[
+            _Tracker(url="http://a.example/announce", status=4, msg="Connection timed out"),
+            _Tracker(url="http://b.example/announce", status=4, msg="Unregistered torrent"),
+        ],
+    )
+    qbt = _make_issue_qbt(t, config=cfg)
+    qbt._torrentissue_override = [t]
+    ru = make_remove_unregistered(qbt)
+
+    with patch.object(ru, "check_max_limit_and_delete") as mock_del:
+        ru.process_torrent_issues()
+
+    assert mock_del.called
+    assert not qbt.config.notify_calls
+
+
+def test_process_issues_defers_when_tracker_still_updating():
+    """A tracker still UPDATING is inconclusive, so removal is deferred."""
+    cfg = FakeConfig(settings={**FakeConfig().settings, "rem_unregistered_grace_minutes": 0})
+    cfg.commands["tag_tracker_error"] = False
+    t = FakeTorrent(
+        name="T.Updating",
+        hash="hupdating",
+        category="Test",
+        added_on=int(time.time()) - 3600,
+        trackers=[
+            _Tracker(url="http://a.example/announce", status=3, msg=""),  # UPDATING
+            _Tracker(url="http://b.example/announce", status=4, msg="Unregistered torrent"),
+        ],
+    )
+    qbt = _make_issue_qbt(t, config=cfg)
+    qbt._torrentissue_override = [t]
+    ru = make_remove_unregistered(qbt)
+
+    with patch.object(ru, "check_max_limit_and_delete") as mock_del:
+        ru.process_torrent_issues()
+
+    assert not mock_del.called
+    assert not qbt.config.notify_calls
+
+
+def test_process_issues_skips_when_any_tracker_working():
+    """A working tracker means the torrent is alive; never removed."""
+    cfg = FakeConfig(settings={**FakeConfig().settings, "rem_unregistered_grace_minutes": 0})
+    cfg.commands["tag_tracker_error"] = False
+    t = FakeTorrent(
+        name="T.Working",
+        hash="hworking",
+        category="Test",
+        added_on=int(time.time()) - 3600,
+        trackers=[
+            _Tracker(url="http://a.example/announce", status=2, msg=""),  # WORKING
+            _Tracker(url="http://b.example/announce", status=4, msg="Unregistered torrent"),
+        ],
+    )
+    qbt = _make_issue_qbt(t, config=cfg)
+    qbt._torrentissue_override = [t]
+    ru = make_remove_unregistered(qbt)
+
+    with patch.object(ru, "check_max_limit_and_delete") as mock_del:
+        ru.process_torrent_issues()
+
+    assert not mock_del.called
+    assert not qbt.config.notify_calls
+
+
 def test_grace_period_blocks_deletion():
     """Grace period prevents deletion of recently added torrent."""
     cfg = FakeConfig(

--- a/tests/core/test_remove_unregistered.py
+++ b/tests/core/test_remove_unregistered.py
@@ -469,7 +469,7 @@ def _make_issue_qbt(torrent, *, config):
     torrentinfo = {
         torrent.name: {
             "Category": torrent.category,
-            "msg": [t.msg.upper() for t in torrent.trackers],
+            "msg": [(t.msg or "").upper() for t in torrent.trackers],
             "status": [t.status for t in torrent.trackers],
         }
     }
@@ -498,6 +498,33 @@ def test_process_issues_detects_unregistered_when_not_last_tracker():
         ],
     )
     cfg.commands["tag_tracker_error"] = False
+    qbt = _make_issue_qbt(t, config=cfg)
+    qbt._torrentissue_override = [t]
+    ru = make_remove_unregistered(qbt)
+
+    with patch.object(ru, "check_max_limit_and_delete") as mock_del:
+        ru.process_torrent_issues()
+
+    assert mock_del.called
+    assert "UNREGISTERED" in mock_del.call_args[0][0].upper()
+    assert not qbt.config.notify_calls  # no swallowed exception
+
+
+def test_process_issues_none_msg_earlier_tracker_still_detects():
+    """A failing tracker with a None message before an unregistered one must not
+    abort detection or crash. Regression for #1358 None-msg handling."""
+    cfg = FakeConfig(settings={**FakeConfig().settings, "rem_unregistered_grace_minutes": 0})
+    cfg.commands["tag_tracker_error"] = False
+    t = FakeTorrent(
+        name="T.NoneMsg",
+        hash="hnonemsg",
+        category="Test",
+        added_on=int(time.time()) - 3600,
+        trackers=[
+            _Tracker(url="http://a.example/announce", status=4, msg=None),
+            _Tracker(url="http://b.example/announce", status=4, msg="err: unregistered torrent"),
+        ],
+    )
     qbt = _make_issue_qbt(t, config=cfg)
     qbt._torrentissue_override = [t]
     ru = make_remove_unregistered(qbt)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -85,7 +85,7 @@ class FakeClient:
 class _Tracker:
     url: str
     status: int = 2  # 2 = working
-    msg: str = ""
+    msg: str | None = ""  # qbittorrentapi can return None; see #1358
     num_seeds: int = 0
     num_peers: int = 0
     num_leeches: int = 0

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -85,7 +85,7 @@ class FakeClient:
 class _Tracker:
     url: str
     status: int = 2  # 2 = working
-    msg: str | None = ""  # qbittorrentapi can return None; see #1358
+    msg: str | None = ""  # qbittorrentapi can return None
     num_seeds: int = 0
     num_peers: int = 0
     num_leeches: int = 0

--- a/tests/test_qbittorrent.py
+++ b/tests/test_qbittorrent.py
@@ -326,6 +326,31 @@ class TestGetTorrentInfo:
         assert hasattr(qbt, "torrentvalid")
 
     @patch("modules.qbittorrent.logger")
+    def test_none_tracker_msg_does_not_crash(self, mock_logger):
+        """A tracker with msg=None must not crash torrentinfo population (#1358)."""
+        torrent = FakeTorrent(
+            name="NoneMsgTorrent",
+            hash="hashnone",
+            trackers=[_Tracker(url="http://tracker1.example/announce", status=4, msg=None)],
+        )
+
+        qbt = MagicMock(spec=Qbt)
+        qbt.config = MagicMock()
+        qbt.config.settings = {
+            "force_auto_tmm": False,
+            "force_auto_tmm_ignore_tags": [],
+        }
+        qbt.config.dry_run = False
+        qbt.config.notify = MagicMock()
+        qbt.torrent_list = [torrent]
+        qbt.torrentfiles = {}
+        qbt.add_torrent_files = MagicMock()
+
+        Qbt.get_torrent_info(qbt)
+
+        assert isinstance(qbt.torrentinfo, dict)
+
+    @patch("modules.qbittorrent.logger")
     def test_populates_torrentissue_list(self, mock_logger):
         """Torrents with broken trackers go to torrentissue list."""
         qbt = MagicMock(spec=Qbt)


### PR DESCRIPTION
## Description

`rem_unregistered` only evaluated the **last** entry in a torrent's tracker list, so an "unregistered" tracker followed by another failing tracker (or a trailing DHT/PeX/LSD pseudo-entry) was never detected — the torrent was silently skipped.

Fixes #1358

### What changed

- Scan **all** failing trackers for an unregistered message instead of only the last one.
- Act only when no tracker is `WORKING` and none is still `UPDATING` / `NOT_CONTACTED` (inconclusive, self-resolving states), so a removal is never decided on incomplete tracker state.
- Guard against a `None` tracker message so it can't abort detection before reaching a genuinely-unregistered tracker.

Grace, `rem_unregistered_max_torrents`, and the recyclebin remain the existing safety net. An opt-in dwell-timer that adds protection against a tracker that *transiently* reports "unregistered"/"not found" during an outage is proposed separately (stacked follow-up PR) to keep this one scoped to the bug.

### Review follow-ups

- Scoped the BHD-specific check in the failing-tracker scan to pass only the tracker URL, so `get_tags()` (config lookups) runs once for the selected tracker instead of once per failing tracker. No behavior change; `check_for_unregistered_torrents_in_bhd` only reads the URL.
- Added a regression test asserting `get_tags()` is called once during a multi-tracker BHD scan (fails 3→1 before the fix).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have modified this PR to merge to the develop branch

## Tests

Added coverage in `tests/core/test_remove_unregistered.py`: unregistered-not-last detection, host-not-found sibling still deletes, a failed/timed-out sibling still deletes, working/updating trackers skip removal, single-tracker unregistered, None-msg-before-unregistered regression, and deferred `get_tags()` in the BHD scan. Full suite green (476 passed).