### PR TITLE
docs: keep code comments minimal and drop issue-number refs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,17 @@
 
 Python tool for managing qBittorrent. Automates tagging, categorization, orphan cleanup, and more.
 
+**Read [`AGENTS.md`](../AGENTS.md) first.** It is the canonical instructions
+file and holds most of the context: branch model, dev environment, test
+commands, file layout, commit conventions, code style, and the comment policy.
+This file only adds the quick-reference below.
+
+## Comments
+- Keep them minimal. Long prose belongs in docstrings and module headers, not
+  on regular code lines.
+- Comment only non-obvious rationale, never what the code already states.
+- No issue/PR numbers (`#1234`) in code comments.
+
 ## Project
 - Python 3.10+, setuptools + pyproject.toml
 - Ruff: line-length=130 (see ruff.toml)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,8 +139,12 @@ the commit in auto-generated release notes.
 - Avoid mutating caller-owned objects. Return new values or copies when state
   must change.
 - Keep functions focused, avoid deep nesting, and use descriptive names.
-- Comments explain non-obvious constraints or rationale, not what the code
-  already states.
+- Keep comments minimal. Reserve long prose for docstrings and module
+  headers. On regular code lines, comment only non-obvious rationale or
+  constraints, never what the code already states, and never a
+  narrative/changelog of what changed.
+- Do not put issue or PR numbers (`#1234`) in code comments. Git history and
+  the PR record are the trail; inline `#NNN` references rot.
 
 ---
 


### PR DESCRIPTION
## What

Adds a code-comment policy to the agent-instruction files:

- Long prose stays in docstrings and module headers.
- Regular code lines get comments only for non-obvious rationale, never a restatement of the code or a changelog of what changed.
- No issue/PR `#NNN` references in code comments (git blame + PR history is the record).

Also makes `.claude/CLAUDE.md` point to `AGENTS.md` as the canonical instructions file, since most context (branch model, dev env, tests, layout, code style) lives there.

## Scope

Docs only. No code or behavior change.