### PR TITLE
ci: add rolling changelog to develop pre-release

### DIFF
--- a/.github/actions/release-notes/action.yml
+++ b/.github/actions/release-notes/action.yml
@@ -38,7 +38,8 @@ runs:
         OUTFILE: ${{ inputs.outfile }}
       run: |
         OVERRIDE="${RELEASE_NOTES_OVERRIDE}"
-        HEAD_LINE="${HEADING:-## What's Changed in v${NEW_VERSION}}"
+        DEFAULT_HEADING="## What's Changed in v${NEW_VERSION}"
+        HEAD_LINE="${HEADING:-$DEFAULT_HEADING}"
 
         if [[ -n "$OVERRIDE" ]]; then
           NOTES="$OVERRIDE"
@@ -58,7 +59,13 @@ runs:
             || true)
 
           if [[ -z "$LOG" && "$DEPS" -eq 0 ]]; then
-            NOTES="${HEAD_LINE}"$'\n'$'\n'"${EMPTY_MESSAGE}"
+            # Prepend a heading only when the caller set one, so the default
+            # (release-pr.yml) empty-range output stays just the message.
+            if [[ -n "$HEADING" ]]; then
+              NOTES="${HEADING}"$'\n'$'\n'"${EMPTY_MESSAGE}"
+            else
+              NOTES="${EMPTY_MESSAGE}"
+            fi
           else
             FEAT=$(echo "$LOG"     | grep -E '^[a-f0-9]+ feat(\(.*\))?:'     || true)
             FIX=$(echo "$LOG"      | grep -E '^[a-f0-9]+ fix(\(.*\))?:'      || true)

--- a/.github/actions/release-notes/action.yml
+++ b/.github/actions/release-notes/action.yml
@@ -1,14 +1,26 @@
 name: Generate release notes
-description: Build categorized release notes from git log (origin/master..HEAD).
+description: Build categorized release notes from a git log range (default origin/master..HEAD).
 
 inputs:
   new-version:
-    description: Version being released, without the leading v.
+    description: Version being released, without the leading v. Used for the default heading.
     required: true
   override:
     description: If non-empty, used verbatim instead of the git-log changelog.
     required: false
     default: ""
+  range:
+    description: git log revision range the changelog is built from.
+    required: false
+    default: origin/master..HEAD
+  heading:
+    description: Markdown heading for the section. Empty falls back to "## What's Changed in v<new-version>".
+    required: false
+    default: ""
+  empty-message:
+    description: Text shown when the range contains no notable commits.
+    required: false
+    default: "No new commits since last release."
   outfile:
     description: Path the generated notes are written to.
     required: true
@@ -20,14 +32,18 @@ runs:
       env:
         RELEASE_NOTES_OVERRIDE: ${{ inputs.override }}
         NEW_VERSION: ${{ inputs.new-version }}
+        RANGE: ${{ inputs.range }}
+        HEADING: ${{ inputs.heading }}
+        EMPTY_MESSAGE: ${{ inputs.empty-message }}
         OUTFILE: ${{ inputs.outfile }}
       run: |
         OVERRIDE="${RELEASE_NOTES_OVERRIDE}"
+        HEAD_LINE="${HEADING:-## What's Changed in v${NEW_VERSION}}"
 
         if [[ -n "$OVERRIDE" ]]; then
           NOTES="$OVERRIDE"
         else
-          RAW=$(git log origin/master..HEAD --oneline --no-merges 2>/dev/null || true)
+          RAW=$(git log "$RANGE" --oneline --no-merges 2>/dev/null || true)
 
           # Collapse dependency bumps to a single count instead of one line each.
           DEPS=$(printf '%s\n' "$RAW" | grep -ciE 'chore\(deps' || true)
@@ -37,12 +53,12 @@ runs:
           # notes become the master commit message and a literal [skip ci] there
           # would make GitHub skip the whole release chain.
           LOG=$(printf '%s\n' "$RAW" \
-            | grep -viE 'chore(\(release\))?: bump VERSION|chore\(deps|\[pre-commit\.ci\]|pre-commit autoupdate|Update SUPPORTED_VERSIONS' \
+            | grep -viE 'chore(\(release\))?: bump VERSION|\[skip-version-bump\]|Update VERSION to|chore\(deps|\[pre-commit\.ci\]|pre-commit autoupdate|Update SUPPORTED_VERSIONS' \
             | sed -E 's/\[(skip ci|ci skip|no ci|skip actions|actions skip)\]/(\1)/Ig; s/\*\*\*NO_CI\*\*\*/(no ci)/Ig' \
             || true)
 
           if [[ -z "$LOG" && "$DEPS" -eq 0 ]]; then
-            NOTES="No new commits since last release."
+            NOTES="${HEAD_LINE}"$'\n'$'\n'"${EMPTY_MESSAGE}"
           else
             FEAT=$(echo "$LOG"     | grep -E '^[a-f0-9]+ feat(\(.*\))?:'     || true)
             FIX=$(echo "$LOG"      | grep -E '^[a-f0-9]+ fix(\(.*\))?:'      || true)
@@ -50,7 +66,7 @@ runs:
             PERF=$(echo "$LOG"     | grep -E '^[a-f0-9]+ perf(\(.*\))?:'     || true)
             DOCS=$(echo "$LOG"     | grep -E '^[a-f0-9]+ docs(\(.*\))?:'     || true)
 
-            NOTES="## What's Changed in v${NEW_VERSION}"$'\n'$'\n'
+            NOTES="${HEAD_LINE}"$'\n'$'\n'
 
             [[ -n "$FEAT" ]]     && NOTES+="### Features"$'\n'"$FEAT"$'\n'$'\n'
             [[ -n "$FIX" ]]      && NOTES+="### Bug Fixes"$'\n'"$FIX"$'\n'$'\n'

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -71,6 +71,55 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.resolve-develop.outputs.sha }}
+          # Full history + tags so the changelog ranges below can be computed.
+          fetch-depth: 0
+
+      - name: Fetch changelog reference points
+        run: git fetch --tags --force origin master
+
+      - name: Resolve changelog boundaries
+        id: bounds
+        env:
+          GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="$(cat VERSION)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          # Last stable tag reachable from master, used only for the section heading.
+          LAST_STABLE="$(git describe --tags --abbrev=0 --match 'v*' origin/master 2>/dev/null || echo '')"
+          echo "stable_heading=## Changes since last stable release${LAST_STABLE:+ ($LAST_STABLE)}" >> "$GITHUB_OUTPUT"
+
+          # Target of the current rolling develop pre-release, captured BEFORE it is
+          # deleted+recreated below, so "since the previous develop build" has a
+          # start point. Skipped when the release is missing, or the recorded commit
+          # is not in this checkout (a force-reset develop can orphan the old build).
+          PREV_SHA="$(gh release view latest-develop --json targetCommitish -q '.targetCommitish' 2>/dev/null || echo '')"
+          if [[ -n "$PREV_SHA" ]] && git rev-parse -q --verify "${PREV_SHA}^{commit}" >/dev/null 2>&1; then
+            echo "prev_sha=$PREV_SHA" >> "$GITHUB_OUTPUT"
+            echo "dev_heading=## Changes since the previous develop build (\`${PREV_SHA:0:7}\`)" >> "$GITHUB_OUTPUT"
+          else
+            echo "prev_sha=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Changelog since last stable release
+        uses: ./.github/actions/release-notes
+        with:
+          new-version: ${{ steps.bounds.outputs.version }}
+          range: origin/master..${{ needs.resolve-develop.outputs.sha }}
+          heading: ${{ steps.bounds.outputs.stable_heading }}
+          empty-message: "No new commits since the last stable release."
+          outfile: /tmp/since_stable.md
+
+      - name: Changelog since previous develop build
+        if: steps.bounds.outputs.prev_sha != ''
+        uses: ./.github/actions/release-notes
+        with:
+          new-version: ${{ steps.bounds.outputs.version }}
+          range: ${{ steps.bounds.outputs.prev_sha }}..${{ needs.resolve-develop.outputs.sha }}
+          heading: ${{ steps.bounds.outputs.dev_heading }}
+          empty-message: "No new commits since the previous develop build."
+          outfile: /tmp/since_dev.md
 
       - name: Download prepared release assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -87,7 +136,21 @@ jobs:
           TAG="latest-develop"
           HEAD_SHA="${{ needs.resolve-develop.outputs.sha }}"
           RELEASE_ERROR="$(mktemp)"
-          trap 'rm -f "$RELEASE_ERROR"' EXIT
+          NOTES_FILE="$(mktemp)"
+          trap 'rm -f "$RELEASE_ERROR" "$NOTES_FILE"' EXIT
+
+          # Assemble the rolling notes: build preamble + a "since last stable" and
+          # (when available) a "since the previous develop build" changelog section.
+          {
+            printf 'Rolling pre-release built from the latest `develop` commit (`%s`).\n' "$HEAD_SHA"
+            printf 'Auto-updated on every merge to develop — this is a development build, not a stable release.\n\n'
+            cat /tmp/since_stable.md
+            if [[ -f /tmp/since_dev.md ]]; then
+              printf '\n\n'
+              cat /tmp/since_dev.md
+            fi
+            printf '\n'
+          } > "$NOTES_FILE"
 
           # The GitHub API cannot move an existing tag to a new commit, so delete
           # the rolling release + its tag and recreate both at the current HEAD.
@@ -107,7 +170,7 @@ jobs:
           gh release create "$TAG" \
             --target "$HEAD_SHA" \
             --title "Develop build ($VERSION)" \
-            --notes "Rolling pre-release built from the latest \`develop\` commit (\`$HEAD_SHA\`). Auto-updated on every merge to develop — this is a development build, not a stable release." \
+            --notes-file "$NOTES_FILE" \
             --prerelease \
             --latest=false \
             release-assets/*


### PR DESCRIPTION
## What

The rolling `latest-develop` pre-release notes now carry a real changelog instead of a static blurb, in two sections:

- **Since last stable release** (`origin/master..develop`)
- **Since the previous develop build** (`<prev latest-develop SHA>..develop`) — the prior `latest-develop` target, captured before the release is deleted+recreated

## How

- `.github/actions/release-notes` gains three optional inputs: `range` (default `origin/master..HEAD`), `heading`, `empty-message`. Defaults preserve the existing `release-pr.yml` output exactly, so the section is now reused for the develop build.
- `develop.yml`'s `develop-prerelease` job: full-history checkout (`fetch-depth: 0`) + `git fetch --tags origin master`, resolves the last stable tag and the previous develop-build SHA, calls the action twice, and assembles the notes via `--notes-file`. The since-dev section is skipped when there is no prior build or its commit was orphaned by a force-reset.
- Noise filter extended to drop develop VERSION-bump commits (`[skip-version-bump]` / `Update VERSION to`) so a bump-only range renders the empty message rather than a blank heading.

## Verified

Ran the changelog shell locally against real history: since-stable renders the empty message post-release, since-dev groups fixes + dependency count, and the `prev == HEAD` case renders the empty message. YAML parses; actionlint clean apart from a benign SC2016 info on intentional literal-backtick markdown.
